### PR TITLE
release ver 2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,17 +197,19 @@ if you use `vector<SomeType> vec;`, when `vec` will be resized every receiving O
 
 ### 2016/01/02 [ver 0.2.0](releases/tag/v2_0_0) release
 
-* after this release, we will only test on oF0.9.0~
+* *after this release, we will only test on oF0.9.0~*
 * add iterators to [ofxOscSubscriberManager](API_Reference.md#Advanced_ofxOscSubscriberManager)
+* add iterators to [ofxOscPublisherManager](API_Reference.md#Advanced_ofxOscPublisherManager)
 * add all port operation to ofxUnsubscribeOsc, ofxNotifyToSubscribedOsc, ofxRemoveLeakedOscPicker
 * add ofxSetLeakedOscPickerAll
 * add ofxSubscribeOsc with `std::initializer_list<int> port` and `std::initializer_list<std::string> addresses`
 * add iterators to [ofxOscPublisherManager](API_Reference.md#Advanced_ofxOscPublisherManager)
 * add all port operation to ofxUnpublishOsc, ofxUnregisterPublishingOsc
-* add `std::` prefix
-* some bugfix around lambda
+* add feature publishing r-value. (i.e., you can do `ofxPublishOsc(host, port, "/bar", "value!!")`)
 * add useful macro `SubscribeOsc(port, name)` is same as `ofxSubscribeOsc(port, "/name", name)` (porposed by [hanasaan](https://github.com/hanasaan). thanks!!)
+* add `std::` prefix
 * cleaning up conditional macro about oF0.8.x
+* some bugfix around lambda
 * TODO: update some API Documentations
 
 ### 2016/01/02 [ver 0.1.2](releases/tag/v0_1_2) release

--- a/README.md
+++ b/README.md
@@ -191,6 +191,15 @@ if you use `vector<SomeType> vec;`, when `vec` will be resized every receiving O
 
 ## <a name="UpdateHistory">Update history</a>
 
+### 2015/XX/XX ver 0.1.2 release
+
+* add new feature [ofxNotifyToSubscribedOsc](#SimpleAPI_ofxNotifyToSubscribedOsc) (proposed by [satcy](http://github.com/satcy). thanks!!)
+* add iterators to [ofxOscSubscriberManager](API_Reference.md#Advanced_ofxOscSubscriberManager)
+* add all port operation to ofxUnsubscribeOsc, ofxNotifyToSubscribedOsc, ofxRemoveLeakedOscPicker
+* add ofxSetLeakedOscPickerAll (only oF0.9.0~)
+* add `ofxSubscribeOsc` with `std::initializer_list<int> port` and `std::initializer_list<std::string> addresses` (only oF0.9.0~)
+* add `std::` prefix
+
 ### 2015/09/17 ver 0.1.1 release
 
 * support [ofParameter](#SupportedTypes_ofParameter)
@@ -273,6 +282,7 @@ MIT License.
 * [SHIMIZU Motoi](http://github.com/motoishmz)
 * [IWATANI Nariaki](http://github.com/nariakiiwatani)
 * [USAMI Takuto](http://github.com/usm916)
+* [HORII Satoshi](http://github.com/satcy)
 
 ## <a name="AtTheLast">At the last</a>
 

--- a/README.md
+++ b/README.md
@@ -33,8 +33,7 @@ if you use oF0.9.0~, then you can use `std::function<void(ofxOscMessage &)>`! de
 
 ## <a name="HowToUse">How to use</a>
 
-```
-
+```cpp
 class ofApp : public ofBaseApp {
 	int foo;
 	ofColor c;

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ easy utility for publish/subscribe OSC message.
 
 ## Dependencies
 
-* ofxOsc (maybe oF0.8.2~)
+* ofxOsc
 
 ## Notice
 
@@ -12,7 +12,7 @@ easy utility for publish/subscribe OSC message.
 * if you use oF0.9.0~, then you can use `std::function<void(ofxOscMessage &)>`! detail: [API Reference](API_Reference.md#API_lambda_callback)
 * **if you use oF0.8.2~0.8.4, then you can use [v0.1.2](releases/tag/v0_1_2)**
 * if you have challange spirit, please use dev/main branch.
-* if you want to join development ofxPubSubOsc, open the issue and post the PR for dev/main.
+* if you want to join development ofxPubSubOsc, open the issue and post the PR for [dev/main](tree/dev/main).
 
 ## TOC
 
@@ -191,7 +191,6 @@ if you use `vector<SomeType> vec;`, when `vec` will be resized every receiving O
 * pair of `U &that`, `T (U::\*callback)(ofxOscMessage &)`;
 * pair of `U \*that`, `T (U::\*callback)(ofxOscMessage &)`;
 * `std::function<void(ofxOscMessage &)>`
-	* (oF0.9.0~)
 
 ## <a name="UpdateHistory">Update history</a>
 
@@ -206,6 +205,7 @@ if you use `vector<SomeType> vec;`, when `vec` will be resized every receiving O
 * add iterators to [ofxOscPublisherManager](API_Reference.md#Advanced_ofxOscPublisherManager)
 * add all port operation to ofxUnpublishOsc, ofxUnregisterPublishingOsc
 * add feature publishing r-value. (i.e., you can do `ofxPublishOsc(host, port, "/bar", "value!!")`)
+* add `const` to lambda callback (proposed by [satoruhiga](https://github.com/satoruhiga). thanks!!)
 * add useful macro `SubscribeOsc(port, name)` is same as `ofxSubscribeOsc(port, "/name", name)` (porposed by [hanasaan](https://github.com/hanasaan). thanks!!)
 * add `std::` prefix
 * cleaning up conditional macro about oF0.8.x

--- a/README.md
+++ b/README.md
@@ -197,7 +197,9 @@ if you use `vector<SomeType> vec;`, when `vec` will be resized every receiving O
 * add iterators to [ofxOscSubscriberManager](API_Reference.md#Advanced_ofxOscSubscriberManager)
 * add all port operation to ofxUnsubscribeOsc, ofxNotifyToSubscribedOsc, ofxRemoveLeakedOscPicker
 * add ofxSetLeakedOscPickerAll (only oF0.9.0~)
-* add `ofxSubscribeOsc` with `std::initializer_list<int> port` and `std::initializer_list<std::string> addresses` (only oF0.9.0~)
+* add ofxSubscribeOsc with `std::initializer_list<int> port` and `std::initializer_list<std::string> addresses` (only oF0.9.0~)
+* add iterators to [ofxOscPublisherManager](API_Reference.md#Advanced_ofxOscPublisherManager)
+* add all port operation to ofxUnpublishOsc, ofxUnregisterPublishingOsc
 * add `std::` prefix
 
 ### 2015/09/17 ver 0.1.1 release

--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ if you use `vector<SomeType> vec;`, when `vec` will be resized every receiving O
 
 ### 2016/01/02 [ver 0.2.0](releases/tag/v2_0_0) release
 
-* this is only tested on oF0.9.0~
+* after this release, we will only test on oF0.9.0~
 * add iterators to [ofxOscSubscriberManager](API_Reference.md#Advanced_ofxOscSubscriberManager)
 * add all port operation to ofxUnsubscribeOsc, ofxNotifyToSubscribedOsc, ofxRemoveLeakedOscPicker
 * add ofxSetLeakedOscPickerAll
@@ -207,6 +207,10 @@ if you use `vector<SomeType> vec;`, when `vec` will be resized every receiving O
 * add iterators to [ofxOscPublisherManager](API_Reference.md#Advanced_ofxOscPublisherManager)
 * add all port operation to ofxUnpublishOsc, ofxUnregisterPublishingOsc
 * add `std::` prefix
+* some bugfix around lambda
+* add useful macro `SubscribeOsc(port, name)` is same as `ofxSubscribeOsc(port, "/name", name)` (porposed by [hanasaan](https://github.com/hanasaan). thanks!!)
+* cleaning up conditional macro about oF0.8.x
+* TODO: update some API Documentations
 
 ### 2016/01/02 [ver 0.1.2](releases/tag/v0_1_2) release
 

--- a/README.md
+++ b/README.md
@@ -6,15 +6,13 @@ easy utility for publish/subscribe OSC message.
 
 * ofxOsc (maybe oF0.8.2~)
 
-this addon is tested with oF0.9.0~
+## Notice
 
-if you use oF0.9.0~, then you can use `std::function<void(ofxOscMessage &)>`! detail: [API Reference](API_Reference.md#API_lambda_callback)
-
-**if you use oF0.8.2~0.8.4, then you can use [v0.1.2](releases/tag/v0_1_2)**
-
-if you have challange spirit, please use dev/main branch.
-
-if you want to join development ofxPubSubOsc, open the issue and post the PR for dev/main.
+* this addon is tested with oF0.9.0~
+* if you use oF0.9.0~, then you can use `std::function<void(ofxOscMessage &)>`! detail: [API Reference](API_Reference.md#API_lambda_callback)
+* **if you use oF0.8.2~0.8.4, then you can use [v0.1.2](releases/tag/v0_1_2)**
+* if you have challange spirit, please use dev/main branch.
+* if you want to join development ofxPubSubOsc, open the issue and post the PR for dev/main.
 
 ## TOC
 

--- a/README.md
+++ b/README.md
@@ -6,9 +6,11 @@ easy utility for publish/subscribe OSC message.
 
 * ofxOsc (maybe oF0.8.2~)
 
-this addon is tested with oF0.8.4~
+this addon is tested with oF0.9.0~
 
 if you use oF0.9.0~, then you can use `std::function<void(ofxOscMessage &)>`! detail: [API Reference](API_Reference.md#API_lambda_callback)
+
+**if you use oF0.8.2~0.8.4, then you can use [v0.1.2](releases/tag/v0_1_2)**
 
 if you have challange spirit, please use dev/main branch.
 
@@ -195,75 +197,26 @@ if you use `vector<SomeType> vec;`, when `vec` will be resized every receiving O
 
 ## <a name="UpdateHistory">Update history</a>
 
-### 2015/XX/XX ver 0.1.2 release
+### 2016/01/02 [ver 0.2.0](releases/tag/v2_0_0) release
 
-* add new feature [ofxNotifyToSubscribedOsc](#SimpleAPI_ofxNotifyToSubscribedOsc) (proposed by [satcy](http://github.com/satcy). thanks!!)
+* this is only tested on oF0.9.0~
 * add iterators to [ofxOscSubscriberManager](API_Reference.md#Advanced_ofxOscSubscriberManager)
 * add all port operation to ofxUnsubscribeOsc, ofxNotifyToSubscribedOsc, ofxRemoveLeakedOscPicker
-* add ofxSetLeakedOscPickerAll (only oF0.9.0~)
-* add ofxSubscribeOsc with `std::initializer_list<int> port` and `std::initializer_list<std::string> addresses` (only oF0.9.0~)
+* add ofxSetLeakedOscPickerAll
+* add ofxSubscribeOsc with `std::initializer_list<int> port` and `std::initializer_list<std::string> addresses`
 * add iterators to [ofxOscPublisherManager](API_Reference.md#Advanced_ofxOscPublisherManager)
 * add all port operation to ofxUnpublishOsc, ofxUnregisterPublishingOsc
 * add `std::` prefix
 
-### 2015/09/17 ver 0.1.1 release
+### 2016/01/02 [ver 0.1.2](releases/tag/v0_1_2) release
 
-* support [ofParameter](#SupportedTypes_ofParameter)
-* support [ofParameterGroup](API_Reference.md#Advanced_how_to_subscribe_ofParameterGroup) for ofxSubscirbeOsc
-* add [ofxRegisterPublishingOsc](#ofxRegisterPublishingOsc)
-* add [ofxSetPublisherUsingBundle](API_Reference.md#ofxSetPublisherUsingBundle)
-* support 0.8.1 (not support ofBuffer as blob)
-* update README and [API_Reference.md](API_Reference.md)
-
-### 2015/08/31 ver 0.1.0 release
-
-* add [lambda function callback](API_Reference.md#API_lambda_callback) for ofxSubscirbeOsc
-* update README and [API_Reference.md](API_Reference.md)
+* this is *final update added new feature, with oF0.8.4 support*
+* after this release, "ver 0.1.x will only bugfie about supporting oF0.8.4
+* add new feature ofxNotifyToSubscribedOsc (proposed by [satcy](http://github.com/satcy/). thanks!!)
 * some bugfix
 
-### 2015/06/10 ver 0.0.8 release
+### [Older update histories](Update_History.md)
 
-* add [ofxPublishAsArray](API_Reference.md#API_ofxPublishAsArray)
-* enable to use in publish `T (U::*)() const`
-* update README and [API_Reference.md](API_Reference.md)
-* add [Legacy style pick up leaked OSC](API_Reference.md#Advanced_LegacyStylePickUpLeakedOSCMessage)
-* add some doxygen texts
-* some bugfix
-
-### 2015/05/19 ver 0.0.7 release
-
-* add [ofxPublishOscIf](API_Reference.md#API_ofxPublishOscIf)
-* some bugfix
-
-### 2015/05/17 ver 0.0.6 release
-
-* add publish ofBuffer as blob
-* some bugfix
-* big change on inner class structure
-
-### 2015/05/15 ver 0.0.5 release
-
-* add system about [pick up leaked OSC messages](API_Reference.md#API_ofxSetLeakedOscPicker)
-* some bugfix
-* add examples
-
-### 2015/05/11 ver 0.0.4 release
-
-* support ofMatrix3x3/4x4, ofQuaternion, ofBuffer (only subscribe now), vector<ofXXX>, ofXXX[]
-* bugfix for Visual Studio
-
-### 2015/05/11 ver 0.0.3 release
-
-* add subscribe with callback
-
-### 2015/05/11 ver 0.0.2 release
-
-* rename from ofxOscSubscriber
-* add ofxOscPublisher
-
-### 2015/05/09 ver 0.0.1 release
-
-* initial
 
 #### about Versioning
 

--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ if you use `vector<SomeType> vec;`, when `vec` will be resized every receiving O
 
 * this is *final update added new feature, with oF0.8.4 support*
 * after this release, "ver 0.1.x will only bugfie about supporting oF0.8.4
-* add new feature ofxNotifyToSubscribedOsc (proposed by [satcy](http://github.com/satcy/). thanks!!)
+* add new feature ofxNotifyToSubscribedOsc (proposed by [satcy](https://github.com/satcy). thanks!!)
 * some bugfix
 
 ### [Older update histories](Update_History.md)
@@ -235,15 +235,15 @@ MIT License.
 
 ## <a name="SuppotingContributor">Supporting Contributor</a>
 
-* [HIEDA Naoto](http://github.com/micuat)
+* [HIEDA Naoto](https://github.com/micuat)
 
 ## <a name="SpecialThanks">Special Thanks</a>
 
-* [HIGA Satoru](http://github.com/satoruhiga)
-* [SHIMIZU Motoi](http://github.com/motoishmz)
-* [IWATANI Nariaki](http://github.com/nariakiiwatani)
-* [USAMI Takuto](http://github.com/usm916)
-* [HORII Satoshi](http://github.com/satcy)
+* [HIGA Satoru](https://github.com/satoruhiga)
+* [SHIMIZU Motoi](https://github.com/motoishmz)
+* [IWATANI Nariaki](https://github.com/nariakiiwatani)
+* [USAMI Takuto](https://github.com/usm916)
+* [HORII Satoshi](https://github.com/satcy)
 
 ## <a name="AtTheLast">At the last</a>
 

--- a/Update_History.md
+++ b/Update_History.md
@@ -1,0 +1,79 @@
+# ofxPubSubOsc Update History
+
+## 2016/01/02 [ver 0.2.0](releases/tag/v0_2_0) release
+
+* after this release, we will only test on oF0.9.0~
+* add iterators to [ofxOscSubscriberManager](API_Reference.md#Advanced_ofxOscSubscriberManager)
+* add all port operation to ofxUnsubscribeOsc, ofxNotifyToSubscribedOsc, ofxRemoveLeakedOscPicker
+* add ofxSetLeakedOscPickerAll
+* add ofxSubscribeOsc with `std::initializer_list<int> port` and `std::initializer_list<std::string> addresses`
+* add iterators to [ofxOscPublisherManager](API_Reference.md#Advanced_ofxOscPublisherManager)
+* add all port operation to ofxUnpublishOsc, ofxUnregisterPublishingOsc
+* add `std::` prefix
+* some bugfix around lambda
+
+## 2016/01/02 [ver 0.1.2](releases/tag/v0_1_2) release
+
+* this is *final update added new feature, with oF0.8.4 support*
+* after this release, "ver 0.1.x will only bugfie about supporting oF0.8.4
+* add new feature ofxNotifyToSubscribedOsc (proposed by [satcy](http://github.com/satcy/). thanks!!)
+* some bugfix
+
+## 2015/09/17 [ver 0.1.1](releases/tag/v0_1_1) release
+
+* support [ofParameter](#SupportedTypes_ofParameter)
+* support [ofParameterGroup](API_Reference.md#Advanced_how_to_subscribe_ofParameterGroup) for ofxSubscirbeOsc
+* add [ofxRegisterPublishingOsc](#ofxRegisterPublishingOsc)
+* add [ofxSetPublisherUsingBundle](API_Reference.md#ofxSetPublisherUsingBundle)
+* support 0.8.1 (not support ofBuffer as blob)
+* update README and [API_Reference.md](API_Reference.md)
+
+## 2015/08/31 [ver 0.1.0](releases/tag/v0_1_0) release
+
+* add [lambda function callback](API_Reference.md#API_lambda_callback) for ofxSubscirbeOsc
+* update README and [API_Reference.md](API_Reference.md)
+* some bugfix
+
+## 2015/06/10 [ver 0.0.8](releases/tag/v0_0_8) release
+
+* add [ofxPublishAsArray](API_Reference.md#API_ofxPublishAsArray)
+* enable to use in publish `T (U::*)() const`
+* update README and [API_Reference.md](API_Reference.md)
+* add [Legacy style pick up leaked OSC](API_Reference.md#Advanced_LegacyStylePickUpLeakedOSCMessage)
+* add some doxygen texts
+* some bugfix
+
+## 2015/05/19 [ver 0.0.7](releases/tag/v0_0_7) release
+
+* add [ofxPublishOscIf](API_Reference.md#API_ofxPublishOscIf)
+* some bugfix
+
+## 2015/05/17 [ver 0.0.6](releases/tag/v0_0_6) release
+
+* add publish ofBuffer as blob
+* some bugfix
+* big change on inner class structure
+
+## 2015/05/15 [ver 0.0.5](releases/tag/v0_0_5) release
+
+* add system about [pick up leaked OSC messages](API_Reference.md#API_ofxSetLeakedOscPicker)
+* some bugfix
+* add examples
+
+## 2015/05/11 [ver 0.0.4](releases/tag/v0_0_4) release
+
+* support ofMatrix3x3/4x4, ofQuaternion, ofBuffer (only subscribe now), vector<ofXXX>, ofXXX[]
+* bugfix for Visual Studio
+
+## 2015/05/11 [ver 0.0.3](releases/tag/v0_0_3) release
+
+* add subscribe with callback
+
+## 2015/05/11 [ver 0.0.2](releases/tag/v0_0_2) release
+
+* rename from ofxOscSubscriber
+* add ofxOscPublisher
+
+## 2015/05/09 [ver 0.0.1](releases/tag/v0_0_1) release
+
+* initial

--- a/Update_History.md
+++ b/Update_History.md
@@ -2,17 +2,19 @@
 
 ## 2016/01/02 [ver 0.2.0](releases/tag/v0_2_0) release
 
-* after this release, we will only test on oF0.9.0~
+* *after this release, we will only test on oF0.9.0~*
 * add iterators to [ofxOscSubscriberManager](API_Reference.md#Advanced_ofxOscSubscriberManager)
+* add iterators to [ofxOscPublisherManager](API_Reference.md#Advanced_ofxOscPublisherManager)
 * add all port operation to ofxUnsubscribeOsc, ofxNotifyToSubscribedOsc, ofxRemoveLeakedOscPicker
 * add ofxSetLeakedOscPickerAll
 * add ofxSubscribeOsc with `std::initializer_list<int> port` and `std::initializer_list<std::string> addresses`
 * add iterators to [ofxOscPublisherManager](API_Reference.md#Advanced_ofxOscPublisherManager)
 * add all port operation to ofxUnpublishOsc, ofxUnregisterPublishingOsc
-* add `std::` prefix
-* some bugfix around lambda
+* add feature publishing r-value. (i.e., you can do `ofxPublishOsc(host, port, "/bar", "value!!")`)
 * add useful macro `SubscribeOsc(port, name)` is same as `ofxSubscribeOsc(port, "/name", name)` (porposed by [hanasaan](https://github.com/hanasaan). thanks!!)
+* add `std::` prefix
 * cleaning up conditional macro about oF0.8.x
+* some bugfix around lambda
 * TODO: update some API Documentations
 
 ## 2016/01/02 [ver 0.1.2](releases/tag/v0_1_2) release

--- a/Update_History.md
+++ b/Update_History.md
@@ -11,6 +11,9 @@
 * add all port operation to ofxUnpublishOsc, ofxUnregisterPublishingOsc
 * add `std::` prefix
 * some bugfix around lambda
+* add useful macro `SubscribeOsc(port, name)` is same as `ofxSubscribeOsc(port, "/name", name)` (porposed by [hanasaan](https://github.com/hanasaan). thanks!!)
+* cleaning up conditional macro about oF0.8.x
+* TODO: update some API Documentations
 
 ## 2016/01/02 [ver 0.1.2](releases/tag/v0_1_2) release
 

--- a/src/details/ofxpubsubosc_publish_value_wrappers.h
+++ b/src/details/ofxpubsubosc_publish_value_wrappers.h
@@ -137,8 +137,8 @@ namespace ofxpubsubosc {
         
         template <typename T, size_t s>
         struct array_publisher {
-            typedef const T inner_type;
-            typedef T const (&const_array_t)[s];
+            using inner_type = const T;
+            using const_array_t = T const (&)[s];
             
             array_publisher(T *v)
             : stream(pointer_stream_factory(v)) {}
@@ -171,8 +171,8 @@ namespace ofxpubsubosc {
         
         template <typename T, size_t s>
         struct array_buffer {
-            typedef T inner_type;
-            typedef T (&array_t)[s];
+            using inner_type = T;
+            using array_t = T (&)[s];
             
             array_buffer() : v(malloc(sizeof(T) * s)) {}
             virtual ~array_buffer() { free(v); v = NULL; }

--- a/src/details/ofxpubsubosc_publish_value_wrappers.h
+++ b/src/details/ofxpubsubosc_publish_value_wrappers.h
@@ -114,23 +114,23 @@ namespace ofxpubsubosc {
 #pragma mark factory
         
         template <typename T>
-        shared_ptr<abstract_pointer_stream<T> > pointer_stream_factory(T *t) {
-            return shared_ptr<abstract_pointer_stream<T> >(new raw_pointer_stream<T>(t));
+        std::shared_ptr<abstract_pointer_stream<T> > pointer_stream_factory(T *t) {
+            return std::shared_ptr<abstract_pointer_stream<T> >(new raw_pointer_stream<T>(t));
         }
         
         template <typename T>
-        shared_ptr<abstract_pointer_stream<T> > pointer_stream_factory(T (*g)()) {
-            return shared_ptr<abstract_pointer_stream<T> >(new getter_function_pointer_stream<T>(g));
+        std::shared_ptr<abstract_pointer_stream<T> > pointer_stream_factory(T (*g)()) {
+            return std::shared_ptr<abstract_pointer_stream<T> >(new getter_function_pointer_stream<T>(g));
         }
         
         template <typename T, typename U>
-        shared_ptr<abstract_pointer_stream<T> > pointer_stream_factory(U &that, T (U::*g)()) {
-            return shared_ptr<abstract_pointer_stream<T> >(new getter_method_pointer_stream<T, U>(that, g));
+        std::shared_ptr<abstract_pointer_stream<T> > pointer_stream_factory(U &that, T (U::*g)()) {
+            return std::shared_ptr<abstract_pointer_stream<T> >(new getter_method_pointer_stream<T, U>(that, g));
         }
         
         template <typename T, typename U>
-        shared_ptr<abstract_pointer_stream<T> > pointer_stream_factory(const U &that, T (U::*g)() const) {
-            return shared_ptr<abstract_pointer_stream<T> >(new const_getter_method_pointer_stream<T, U>(that, g));
+        std::shared_ptr<abstract_pointer_stream<T> > pointer_stream_factory(const U &that, T (U::*g)() const) {
+            return std::shared_ptr<abstract_pointer_stream<T> >(new const_getter_method_pointer_stream<T, U>(that, g));
         }
         
 #pragma mark array publisher
@@ -161,7 +161,7 @@ namespace ofxpubsubosc {
             operator const_array_t() { return get(); };
             const_array_t get() { return reinterpret_cast<const_array_t>(stream.get()); };
         protected:
-            shared_ptr<abstract_pointer_stream<T> > stream;
+            std::shared_ptr<abstract_pointer_stream<T> > stream;
         };
         
         template <typename T, size_t s>

--- a/src/details/ofxpubsubosc_settings.h
+++ b/src/details/ofxpubsubosc_settings.h
@@ -20,4 +20,10 @@
 #   define ENABLE_FUNCTIONAL 1
 #endif
 
+#if __cplusplus <= 199711L
+#   define ENABLE_CPP11 0
+#else
+#   define ENABLE_CPP11 1
+#endif
+
 #endif

--- a/src/details/ofxpubsubosc_settings.h
+++ b/src/details/ofxpubsubosc_settings.h
@@ -16,4 +16,8 @@
 
 #define OFX_PUBSUBOSC_MULTISUBSCRIBE 1
 
+#if (OF_VERSION_MAJOR < 0) && (OF_VERSION_MINOR < 9)
+#   error you can use https://github.com/2bbb/ofxPubSubOsc/releases/tag/v0_1_2
+#endif
+
 #endif

--- a/src/details/ofxpubsubosc_settings.h
+++ b/src/details/ofxpubsubosc_settings.h
@@ -16,22 +16,4 @@
 
 #define OFX_PUBSUBOSC_MULTISUBSCRIBE 1
 
-#if (OF_VERSION_MAJOR == 0) && ((OF_VERSION_MINOR < 8) || ((OF_VERSION_MINOR == 8) && (OF_VERSION_PATCH < 2)))
-#   define ENABLE_OF_BUFFER 0
-#else
-#   define ENABLE_OF_BUFFER 1
-#endif
-
-#if (OF_VERSION_MAJOR == 0) && (OF_VERSION_MINOR < 9)
-#   define ENABLE_FUNCTIONAL 0
-#else
-#   define ENABLE_FUNCTIONAL 1
-#endif
-
-#if __cplusplus <= 199711L
-#   define ENABLE_CPP11 0
-#else
-#   define ENABLE_CPP11 1
-#endif
-
 #endif

--- a/src/details/ofxpubsubosc_settings.h
+++ b/src/details/ofxpubsubosc_settings.h
@@ -8,7 +8,7 @@
 #ifndef ofxPubSubDevelopProject_ofxpubsubosc_settings_h
 #define ofxPubSubDevelopProject_ofxpubsubosc_settings_h
 
-#if (OF_VERSION_MAJOR == 0) && (OF_VERSION_MINOR < 8) && (OF_VERSION_PATCH < 2)
+#if (OF_VERSION_MAJOR == 0) && ((OF_VERSION_MINOR < 8) || ((OF_VERSION_MINOR == 8) && (OF_VERSION_PATCH < 2)))
 #   define ENABLE_OF_BUFFER 0
 #else
 #   define ENABLE_OF_BUFFER 1

--- a/src/details/ofxpubsubosc_settings.h
+++ b/src/details/ofxpubsubosc_settings.h
@@ -16,8 +16,8 @@
 
 #define OFX_PUBSUBOSC_MULTISUBSCRIBE 1
 
-#if (OF_VERSION_MAJOR < 0) && (OF_VERSION_MINOR < 9)
-#   error you can use https://github.com/2bbb/ofxPubSubOsc/releases/tag/v0_1_2
+#if (OF_VERSION_MAJOR == 0) && (OF_VERSION_MINOR < 9)
+#   error this version uses C++11. (i.e. only oF0.9.0~). you can use old version ( from https://github.com/2bbb/ofxPubSubOsc/releases/tag/v0_1_2 )
 #endif
 
 #endif

--- a/src/details/ofxpubsubosc_settings.h
+++ b/src/details/ofxpubsubosc_settings.h
@@ -8,6 +8,14 @@
 #ifndef ofxPubSubDevelopProject_ofxpubsubosc_settings_h
 #define ofxPubSubDevelopProject_ofxpubsubosc_settings_h
 
+#pragma mark versioning tags
+
+#define OFX_PUBSUBOSC_VERSION_MAJOR 0
+#define OFX_PUBSUBOSC_VERSION_MINOR 2
+#define OFX_PUBSUBOSC_VERSION_PATCH 0
+
+#define OFX_PUBSUBOSC_MULTISUBSCRIBE 1
+
 #if (OF_VERSION_MAJOR == 0) && ((OF_VERSION_MINOR < 8) || ((OF_VERSION_MINOR == 8) && (OF_VERSION_PATCH < 2)))
 #   define ENABLE_OF_BUFFER 0
 #else

--- a/src/details/ofxpubsubosc_settings.h
+++ b/src/details/ofxpubsubosc_settings.h
@@ -14,7 +14,7 @@
 #   define ENABLE_OF_BUFFER 1
 #endif
 
-#if (OF_VERSION_MAJOR == 0) && OF_VERSION_MINOR < 9
+#if (OF_VERSION_MAJOR == 0) && (OF_VERSION_MINOR < 9)
 #   define ENABLE_FUNCTIONAL 0
 #else
 #   define ENABLE_FUNCTIONAL 1

--- a/src/details/ofxpubsubosc_subscribe_value_wrappers.h
+++ b/src/details/ofxpubsubosc_subscribe_value_wrappers.h
@@ -46,23 +46,23 @@ namespace ofxpubsubosc {
         };
         
         template <typename T>
-        shared_ptr<abstract_stream<T> > stream_factory(T &t) {
-            return shared_ptr<abstract_stream<T> >(new raw_stream<T>(t));
+        std::shared_ptr<abstract_stream<T> > stream_factory(T &t) {
+            return std::shared_ptr<abstract_stream<T> >(new raw_stream<T>(t));
         }
         
         template <typename T, typename U>
-        shared_ptr<abstract_stream<T> > stream_factory(U (*setter)(T)) {
-            return shared_ptr<abstract_stream<T> >(new setter_function_stream<T, U>(setter));
+        std::shared_ptr<abstract_stream<T> > stream_factory(U (*setter)(T)) {
+            return std::shared_ptr<abstract_stream<T> >(new setter_function_stream<T, U>(setter));
         }
         
         template <typename T, typename U, typename C>
-        shared_ptr<abstract_stream<T> > stream_factory(C &o, U (C::*setter)(T)) {
-            return shared_ptr<abstract_stream<T> >(new setter_method_stream<T, U, C>(o, setter));
+        std::shared_ptr<abstract_stream<T> > stream_factory(C &o, U (C::*setter)(T)) {
+            return std::shared_ptr<abstract_stream<T> >(new setter_method_stream<T, U, C>(o, setter));
         }
         
         template <typename T, typename U, typename C>
-        shared_ptr<abstract_stream<T> > stream_factory(C *o, U (C::*setter)(T)) {
-            return shared_ptr<abstract_stream<T> >(new setter_method_stream<T, U, C>(*o, setter));
+        std::shared_ptr<abstract_stream<T> > stream_factory(C *o, U (C::*setter)(T)) {
+            return std::shared_ptr<abstract_stream<T> >(new setter_method_stream<T, U, C>(*o, setter));
         }
     }
 };

--- a/src/details/ofxpubsubosc_type_traits.h
+++ b/src/details/ofxpubsubosc_type_traits.h
@@ -14,84 +14,84 @@
 namespace ofxpubsubosc {
     template <typename T>
     struct type_traits {
-        typedef T inner_type;
+        using inner_type = T;
         static const size_t size = 1;
         static const bool has_array_operator = false;
     };
 
     template <typename T>
     struct type_traits<ofColor_<T> > {
-        typedef T inner_type;
+        using inner_type = T;
         static const size_t size = 4;
         static const bool has_array_operator = true;
     };
 
     template <>
     struct type_traits<ofVec2f> {
-        typedef float inner_type;
+        using inner_type = float;
         static const size_t size = 2;
         static const bool has_array_operator = true;
     };
 
     template <>
     struct type_traits<ofVec3f> {
-        typedef float inner_type;
+        using inner_type = float;
         static const size_t size = 3;
         static const bool has_array_operator = true;
     };
 
     template <>
     struct type_traits<ofVec4f> {
-        typedef float inner_type;
+        using inner_type = float;
         static const size_t size = 4;
         static const bool has_array_operator = true;
     };
 
     template <>
     struct type_traits<ofQuaternion> {
-        typedef float inner_type;
+        using inner_type = float;
         static const size_t size = 4;
         static const bool has_array_operator = true;
     };
 
     template <>
     struct type_traits<ofMatrix3x3> {
-        typedef float inner_type;
+        using inner_type = float;
         static const size_t size = 9;
         static const bool has_array_operator = false; // because don't has "float operator[](int n) const"
     };
 
     template <>
     struct type_traits<ofMatrix4x4> {
-        typedef float inner_type;
+        using inner_type = float;
         static const size_t size = 16;
         static const bool has_array_operator = false;
     };
 
     template <>
     struct type_traits<ofRectangle> {
-        typedef float inner_type;
+        using inner_type = float;
         static const size_t size = 4;
         static const bool has_array_operator = false;
     };
 
     template <typename T, size_t array_size>
     struct type_traits<T[array_size]> {
-        typedef T inner_type;
+        using inner_type = T;
         static const size_t size = ofxpubsubosc::type_traits<T>::size * array_size;
         static const bool has_array_operator = true;
     };
     
     template <typename T, size_t array_size>
     struct type_traits<publish::array_publisher<T, array_size> > {
-        typedef typename publish::array_publisher<T, array_size>::inner_type inner_type;
+        using inner_type = typename publish::array_publisher<T, array_size>::inner_type;
         static const size_t size = ofxpubsubosc::type_traits<T>::size * array_size;
         static const bool has_array_operator = true;
     };
     
     template <typename T, size_t array_size>
     struct type_traits<publish::array_buffer<T, array_size> > {
-        typedef typename publish::array_buffer<T, array_size>::inner_type inner_type;
+        using inner_type = typename publish::array_buffer<T, array_size>::inner_type;
         static const size_t size = ofxpubsubosc::type_traits<T>::size * array_size;
         static const bool has_array_operator = true;
     };

--- a/src/details/ofxpubsubosc_type_utils.h
+++ b/src/details/ofxpubsubosc_type_utils.h
@@ -10,8 +10,8 @@
 #include "ofxpubsubosc_settings.h"
 
 namespace ofxpubsubosc {
-    template <typename T>
-    struct is_not_ofxoscmessage { typedef void type; };
+    template <typename T, typename U = void>
+    struct is_not_ofxoscmessage { typedef U type; };
     template <>
     struct is_not_ofxoscmessage<ofxOscMessage &> {};
     

--- a/src/details/ofxpubsubosc_type_utils.h
+++ b/src/details/ofxpubsubosc_type_utils.h
@@ -16,7 +16,7 @@ namespace ofxpubsubosc {
     namespace {
         template <typename T>
         struct remove_const_reference {
-            typedef T type;
+            using type = T;
         };
         
         template <typename T>
@@ -30,13 +30,13 @@ namespace ofxpubsubosc {
         
         template <typename T>
         struct add_reference_if_non_arithmetic {
-            typedef T& type;
+            using type = T&;
         };
         
 #define define_add_reference_if_non_arithmetic(T) \
 template <> \
 struct add_reference_if_non_arithmetic<T> { \
-typedef T type; \
+using type = T; \
 };
         define_add_reference_if_non_arithmetic(bool);
         define_add_reference_if_non_arithmetic(short);

--- a/src/details/ofxpubsubosc_type_utils.h
+++ b/src/details/ofxpubsubosc_type_utils.h
@@ -11,11 +11,7 @@
 
 namespace ofxpubsubosc {
     template <typename T, typename U = void>
-    struct is_not_ofxoscmessage { typedef U type; };
-    template <>
-    struct is_not_ofxoscmessage<ofxOscMessage &> {};
-    template <>
-    struct is_not_ofxoscmessage<ofxOscMessage> {};
+    using is_not_ofxoscmessage = std::enable_if<!std::is_same<std::remove_reference<T>, ofxOscMessage>::value, U>;
     
     namespace {
         template <typename T>

--- a/src/details/ofxpubsubosc_type_utils.h
+++ b/src/details/ofxpubsubosc_type_utils.h
@@ -14,6 +14,8 @@ namespace ofxpubsubosc {
     struct is_not_ofxoscmessage { typedef U type; };
     template <>
     struct is_not_ofxoscmessage<ofxOscMessage &> {};
+    template <>
+    struct is_not_ofxoscmessage<ofxOscMessage> {};
     
     namespace {
         template <typename T>

--- a/src/details/ofxpubsubosc_type_utils.h
+++ b/src/details/ofxpubsubosc_type_utils.h
@@ -56,20 +56,6 @@ typedef T type; \
     };
 };
 
-#if (OF_VERSION_MAJOR == 0) && (OF_VERSION_MINOR < 9) /* ofColor will provid operator==(const ofColor &c) const from ver. 0.9.0 */
-
-template <typename T>
-bool operator==(const ofColor_<T> &x, const ofColor_<T> &y) {
-    return x == y;
-}
-
-template <typename T>
-bool operator!=(const ofColor_<T> &x, const ofColor_<T> &y) {
-    return x != y;
-}
-
-#endif
-
 bool operator==(const ofMatrix3x3 &x, const ofMatrix3x3 &y) {
     return (x.a == y.a) && (x.b == y.b) && (x.c == y.c)
         && (x.d == y.d) && (x.e == y.e) && (x.f == y.f)
@@ -91,18 +77,10 @@ bool operator!=(const ofMatrix4x4 &x, const ofMatrix4x4 &y) {
     return !operator==(x, y);
 }
 
-#if ENABLE_OF_BUFFER
-
 bool operator==(const ofBuffer &x, const ofBuffer &y) {
-#if OF_VERSION_MINOR < 9
-    return (x.size() == y.size()) && (memcmp(x.getBinaryBuffer(), y.getBinaryBuffer(), x.size()) == 0);
-#else
     return (x.size() == y.size()) && (memcmp(x.getData(), y.getData(), x.size()) == 0);
-#endif
 }
 
 bool operator!=(const ofBuffer &x, const ofBuffer &y) {
     return !operator==(x, y);
 }
-
-#endif

--- a/src/ofxOscPublisher.h
+++ b/src/ofxOscPublisher.h
@@ -1209,6 +1209,9 @@ inline void ofxUnpublishOsc() {
 
 #pragma mark register
 
+/// \name ofxRegisterPublishingOsc
+/// \{
+
 template <typename T>
 inline void ofxRegisterPublishingOsc(const std::string &ip, int port, const std::string &address, T &value) {
     ofxGetOscPublisher(ip, port).doRegister(address, value);
@@ -1239,13 +1242,23 @@ inline void ofxRegisterPublishingOsc(const std::string &ip, int port, const std:
     ofxGetOscPublisher(ip, port).doRegister(address, that, getter);
 }
 
+/// \}
+
 #pragma mark publish registered
+
+/// \name ofxPublishRegisteredOsc
+/// \{
 
 inline void ofxPublishRegisteredOsc(const std::string &ip, int port, const std::string &address) {
     ofxGetOscPublisher(ip, port).publishRegistered(address);
 }
 
+/// \}
+
 #pragma mark unregister
+
+/// \name ofxUnregisterPublishingOsc
+/// \{
 
 inline void ofxUnregisterPublishingOsc(const std::string &ip, int port, const std::string &address) {
     ofxGetOscPublisher(ip, port).unregister(address);
@@ -1263,6 +1276,9 @@ inline void ofxUnregisterPublishingOsc() {
         it->second->unregister();
     }
 }
+
+/// \}
+
 #pragma mark using bundle option
 
 inline void ofxSetPublisherUsingBundle(bool bUseBundle) {

--- a/src/ofxOscPublisher.h
+++ b/src/ofxOscPublisher.h
@@ -1174,24 +1174,24 @@ inline void ofxPublishOsc(const std::initializer_list<ofxOscPublisherManager::De
 
 template <typename ConditionValueRefOrFunction, typename ValueRefOrFunction>
 inline ofxOscPublisherIdentifier ofxPublishOscIf(ConditionValueRefOrFunction &condition, const std::string &ip, int port, const std::string &address, ValueRefOrFunction &value) {
-    ofxGetOscPublisher(ip, port).publishIf(condition, address, value);
+    return ofxGetOscPublisher(ip, port).publishIf(condition, address, value);
 }
 
 template <typename ConditionValueRefOrFunction, typename ObjectPtrOrRef, typename GetterMethod>
 inline ofxOscPublisherIdentifier ofxPublishOscIf(ConditionValueRefOrFunction &condition, const std::string &ip, int port, const std::string &address, ObjectPtrOrRef &that, GetterMethod getter) {
-    ofxGetOscPublisher(ip, port).publishIf(condition, address, that, getter);
+    return ofxGetOscPublisher(ip, port).publishIf(condition, address, that, getter);
 }
 
 #pragma mark condition is method
 
 template <typename ConditionObjectPtrOrRef, typename ConditionMethodReturnsBool, typename ValueRefOrFunction>
 inline ofxOscPublisherIdentifier ofxPublishOscIf(ConditionObjectPtrOrRef &condition, ConditionMethodReturnsBool method, const std::string &ip, int port, const std::string &address, ValueRefOrFunction &value) {
-    ofxGetOscPublisher(ip, port).publishIf(condition, method, address, value);
+    return ofxGetOscPublisher(ip, port).publishIf(condition, method, address, value);
 }
 
 template <typename ConditionObjectPtrOrRef, typename ConditionMethodReturnsBool, typename ObjectRefOrPtr, typename GetterMethod>
 inline ofxOscPublisherIdentifier ofxPublishOscIf(ConditionObjectPtrOrRef &condition, ConditionMethodReturnsBool method, const std::string &ip, int port, const std::string &address, ObjectRefOrPtr &that, GetterMethod getter) {
-    ofxGetOscPublisher(ip, port).publishIf(condition, method, address, *that, getter);
+    return ofxGetOscPublisher(ip, port).publishIf(condition, method, address, *that, getter);
 }
 
 /// \}
@@ -1232,32 +1232,32 @@ inline void ofxUnpublishOsc() {
 
 template <typename T>
 inline ofxOscPublisherIdentifier ofxRegisterPublishingOsc(const std::string &ip, int port, const std::string &address, T &value) {
-    ofxGetOscPublisher(ip, port).doRegister(address, value);
+    return ofxGetOscPublisher(ip, port).doRegister(address, value);
 }
 
 template <typename T>
 inline ofxOscPublisherIdentifier ofxRegisterPublishingOsc(const std::string &ip, int port, const std::string &address, T (*getter)()) {
-    ofxGetOscPublisher(ip, port).doRegister(address, getter);
+    return ofxGetOscPublisher(ip, port).doRegister(address, getter);
 }
 
 template <typename T, typename C>
 inline ofxOscPublisherIdentifier ofxRegisterPublishingOsc(const std::string &ip, int port, const std::string &address, C *that, T (C::*getter)()) {
-    ofxGetOscPublisher(ip, port).doRegister(address, that, getter);
+    return ofxGetOscPublisher(ip, port).doRegister(address, that, getter);
 }
 
 template <typename T, typename C>
 inline ofxOscPublisherIdentifier ofxRegisterPublishingOsc(const std::string &ip, int port, const std::string &address, const C * const that, T (C::*getter)() const) {
-    ofxGetOscPublisher(ip, port).doRegister(address, that, getter);
+    return ofxGetOscPublisher(ip, port).doRegister(address, that, getter);
 }
 
 template <typename T, typename C>
 inline ofxOscPublisherIdentifier ofxRegisterPublishingOsc(const std::string &ip, int port, const std::string &address, C &that, T (C::*getter)()) {
-    ofxGetOscPublisher(ip, port).doRegister(address, that, getter);
+    return ofxGetOscPublisher(ip, port).doRegister(address, that, getter);
 }
 
 template <typename T, typename C>
 inline ofxOscPublisherIdentifier ofxRegisterPublishingOsc(const std::string &ip, int port, const std::string &address, const C &that, T (C::*getter)() const) {
-    ofxGetOscPublisher(ip, port).doRegister(address, that, getter);
+    return ofxGetOscPublisher(ip, port).doRegister(address, that, getter);
 }
 
 /// \}

--- a/src/ofxOscPublisher.h
+++ b/src/ofxOscPublisher.h
@@ -750,6 +750,29 @@ namespace ofx {
             ofRemoveListener(ofEvents().update, this, &OscPublisherManager::update, OF_EVENT_ORDER_AFTER_APP);
         }
         OscPublishers publishers;
+        
+#pragma mark iterator
+    public:
+        typedef OscPublishers::iterator iterator;
+        typedef OscPublishers::const_iterator const_iterator;
+        typedef OscPublishers::reverse_iterator reverse_iterator;
+        typedef OscPublishers::const_reverse_iterator const_reverse_iterator;
+        
+        iterator begin() { return publishers.begin(); }
+        iterator end() { return publishers.end(); }
+        
+        const_iterator begin() const { return publishers.begin(); }
+        const_iterator end() const { return publishers.end(); }
+        const_iterator cbegin() const { return publishers.begin(); }
+        const_iterator cend() const { return publishers.end(); }
+        
+        reverse_iterator rbegin() { return publishers.rbegin(); }
+        reverse_iterator rend() { return publishers.rend(); }
+        
+        const_reverse_iterator rbegin() const { return publishers.rbegin(); }
+        const_reverse_iterator rend() const { return publishers.rend(); }
+        const_reverse_iterator crbegin() const { return publishers.rbegin(); }
+        const_reverse_iterator crend() const { return publishers.crend(); }
     };
     
     bool OscPublisherManager::OscPublisher::bUseBundle = false;

--- a/src/ofxOscPublisher.h
+++ b/src/ofxOscPublisher.h
@@ -484,10 +484,26 @@ namespace ofx {
             }
 
             template <typename T, typename C>
+            void publish(const std::string &address, C *that, T (C::*getter)(), bool whenValueIsChanged = true) {
+                ParameterRef p;
+                if(whenValueIsChanged) p = ParameterRef(new GetterParameter<T, C, true>(*that, getter));
+                else                   p = ParameterRef(new GetterParameter<T, C, false>(*that, getter));
+                publish(address, p);
+            }
+            
+            template <typename T, typename C>
             void publish(const std::string &address, C &that, T (C::*getter)(), bool whenValueIsChanged = true) {
                 ParameterRef p;
                 if(whenValueIsChanged) p = ParameterRef(new GetterParameter<T, C, true>(that, getter));
                 else                   p = ParameterRef(new GetterParameter<T, C, false>(that, getter));
+                publish(address, p);
+            }
+            
+            template <typename T, typename C>
+            void publish(const std::string &address, const C * const that, T (C::*getter)() const, bool whenValueIsChanged = true) {
+                ParameterRef p;
+                if(whenValueIsChanged) p = ParameterRef(new ConstGetterParameter<T, C, true>(*that, getter));
+                else                   p = ParameterRef(new ConstGetterParameter<T, C, false>(*that, getter));
                 publish(address, p);
             }
             
@@ -517,8 +533,22 @@ namespace ofx {
             }
             
             template <typename T, typename C>
+            void publishIf(bool &condition, const std::string &address, C *that, T (C::*getter)()) {
+                ParameterRef p = ParameterRef(new GetterParameter<T, C, false>(*that, getter));
+                p->setCondition(std::shared_ptr<BasicCondition>(new ConditionRef(condition)));
+                publish(address, p);
+            }
+
+            template <typename T, typename C>
             void publishIf(bool &condition, const std::string &address, C &that, T (C::*getter)()) {
                 ParameterRef p = ParameterRef(new GetterParameter<T, C, false>(that, getter));
+                p->setCondition(std::shared_ptr<BasicCondition>(new ConditionRef(condition)));
+                publish(address, p);
+            }
+            
+            template <typename T, typename C>
+            void publishIf(bool &condition, const std::string &address, const C * const that, T (C::*getter)() const) {
+                ParameterRef p = ParameterRef(new ConstGetterParameter<T, C, false>(*that, getter));
                 p->setCondition(std::shared_ptr<BasicCondition>(new ConditionRef(condition)));
                 publish(address, p);
             }
@@ -547,8 +577,22 @@ namespace ofx {
             }
             
             template <typename T, typename C>
+            void publishIf(bool (*condition)(), const std::string &address, C *that, T (C::*getter)()) {
+                ParameterRef p = ParameterRef(new GetterParameter<T, C, false>(*that, getter));
+                p->setCondition(std::shared_ptr<BasicCondition>(new ConditionFunction(condition)));
+                publish(address, p);
+            }
+
+            template <typename T, typename C>
             void publishIf(bool (*condition)(), const std::string &address, C &that, T (C::*getter)()) {
                 ParameterRef p = ParameterRef(new GetterParameter<T, C, false>(that, getter));
+                p->setCondition(std::shared_ptr<BasicCondition>(new ConditionFunction(condition)));
+                publish(address, p);
+            }
+            
+            template <typename T, typename C>
+            void publishIf(bool (*condition)(), const std::string &address, const C * const that, T (C::*getter)() const) {
+                ParameterRef p = ParameterRef(new ConstGetterParameter<T, C, false>(*that, getter));
                 p->setCondition(std::shared_ptr<BasicCondition>(new ConditionFunction(condition)));
                 publish(address, p);
             }
@@ -577,8 +621,22 @@ namespace ofx {
             }
             
             template <typename T, typename C, typename Condition>
+            void publishIf(Condition &condition, bool (Condition::*method)(), const std::string &address, C *that, T (C::*getter)()) {
+                ParameterRef p = ParameterRef(new GetterParameter<T, C, true>(*that, getter));
+                p->setCondition(std::shared_ptr<BasicCondition>(new ConditionMethod<Condition>(condition, method)));
+                publish(address, p);
+            }
+            
+            template <typename T, typename C, typename Condition>
             void publishIf(Condition &condition, bool (Condition::*method)(), const std::string &address, C &that, T (C::*getter)()) {
                 ParameterRef p = ParameterRef(new GetterParameter<T, C, true>(that, getter));
+                p->setCondition(std::shared_ptr<BasicCondition>(new ConditionMethod<Condition>(condition, method)));
+                publish(address, p);
+            }
+            
+            template <typename T, typename C, typename Condition>
+            void publishIf(Condition &condition, bool (Condition::*method)(), const std::string &address, const C * const that, T (C::*getter)() const) {
+                ParameterRef p = ParameterRef(new ConstGetterParameter<T, C, true>(*that, getter));
                 p->setCondition(std::shared_ptr<BasicCondition>(new ConditionMethod<Condition>(condition, method)));
                 publish(address, p);
             }
@@ -607,8 +665,22 @@ namespace ofx {
             }
             
             template <typename T, typename C, typename Condition>
+            void publishIf(const Condition &condition, bool (Condition::*method)() const, const std::string &address, C *that, T (C::*getter)()) {
+                ParameterRef p = ParameterRef(new GetterParameter<T, C, true>(*that, getter));
+                p->setCondition(std::shared_ptr<BasicCondition>(new ConstConditionMethod<Condition>(condition, method)));
+                publish(address, p);
+            }
+            
+            template <typename T, typename C, typename Condition>
             void publishIf(const Condition &condition, bool (Condition::*method)() const, const std::string &address, C &that, T (C::*getter)()) {
                 ParameterRef p = ParameterRef(new GetterParameter<T, C, true>(that, getter));
+                p->setCondition(std::shared_ptr<BasicCondition>(new ConstConditionMethod<Condition>(condition, method)));
+                publish(address, p);
+            }
+            
+            template <typename T, typename C, typename Condition>
+            void publishIf(const Condition &condition, bool (Condition::*method)() const, const std::string &address, const C * const that, T (C::*getter)() const) {
+                ParameterRef p = ParameterRef(new ConstGetterParameter<T, C, true>(*that, getter));
                 p->setCondition(std::shared_ptr<BasicCondition>(new ConstConditionMethod<Condition>(condition, method)));
                 publish(address, p);
             }
@@ -661,8 +733,18 @@ namespace ofx {
             }
             
             template <typename T, typename C>
+            void doRegister(const std::string &address, C *that, T (C::*getter)()) {
+                doRegister(address, ParameterRef(new GetterParameter<T, C, false>(*that, getter)));
+            }
+            
+            template <typename T, typename C>
             void doRegister(const std::string &address, C &that, T (C::*getter)()) {
                 doRegister(address, ParameterRef(new GetterParameter<T, C, false>(that, getter)));
+            }
+            
+            template <typename T, typename C>
+            void doRegister(const std::string &address, const C * const that, T (C::*getter)() const) {
+                doRegister(address, ParameterRef(new ConstGetterParameter<T, C, false>(*that, getter)));
             }
             
             template <typename T, typename C>
@@ -1224,12 +1306,12 @@ inline void ofxRegisterPublishingOsc(const std::string &ip, int port, const std:
 
 template <typename T, typename C>
 inline void ofxRegisterPublishingOsc(const std::string &ip, int port, const std::string &address, C *that, T (C::*getter)()) {
-    ofxGetOscPublisher(ip, port).doRegister(address, *that, getter);
+    ofxGetOscPublisher(ip, port).doRegister(address, that, getter);
 }
 
 template <typename T, typename C>
 inline void ofxRegisterPublishingOsc(const std::string &ip, int port, const std::string &address, const C * const that, T (C::*getter)() const) {
-    ofxGetOscPublisher(ip, port).doRegister(address, *that, getter);
+    ofxGetOscPublisher(ip, port).doRegister(address, that, getter);
 }
 
 template <typename T, typename C>

--- a/src/ofxOscPublisher.h
+++ b/src/ofxOscPublisher.h
@@ -1067,200 +1067,26 @@ inline void ofxPublishOsc(const std::initializer_list<ofxOscPublisherManager::De
 /// \param whenValueIsChanged if this value to false, then we send value every update
 /// \returns void
 
-template <typename T>
-inline void ofxPublishOscIf(bool &condition, const std::string &ip, int port, const std::string &address, T &value) {
+template <typename ConditionValueRefOrFunction, typename ValueRefOrFunction>
+inline void ofxPublishOscIf(ConditionValueRefOrFunction &condition, const std::string &ip, int port, const std::string &address, ValueRefOrFunction &value) {
     ofxGetOscPublisher(ip, port).publishIf(condition, address, value);
 }
 
-/// \brief publish value will be gave by function as an OSC message with an address pattern address to ip:port when condition is true.
-/// template parameter T is suggested by value
-/// \param condition condition of publish typed bool &
-/// \param ip target ip is typed const std::string &
-/// \param port target port is typed int
-/// \param address osc address is typed const std::string &
-/// \param getter this function gives value, is typed T(*)()
-/// \param whenValueIsChanged if this value to false, then we send value every update
-/// \returns void
-
-template <typename T>
-inline void ofxPublishOscIf(bool &condition, const std::string &ip, int port, const std::string &address, T (*getter)()) {
-    ofxGetOscPublisher(ip, port).publishIf(condition, address, getter);
-}
-
-template <typename T, typename C>
-inline void ofxPublishOscIf(bool &condition, const std::string &ip, int port, const std::string &address, C *that, T (C::*getter)()) {
-    ofxGetOscPublisher(ip, port).publishIf(condition, address, *that, getter);
-}
-
-template <typename T, typename C>
-inline void ofxPublishOscIf(bool &condition, const std::string &ip, int port, const std::string &address, const C * const that, T (C::*getter)() const) {
-    ofxGetOscPublisher(ip, port).publishIf(condition, address, *that, getter);
-}
-
-template <typename T, typename C>
-inline void ofxPublishOscIf(bool &condition, const std::string &ip, int port, const std::string &address, C &that, T (C::*getter)()) {
-    ofxGetOscPublisher(ip, port).publishIf(condition, address, that, getter);
-}
-
-template <typename T, typename C>
-inline void ofxPublishOscIf(bool &condition, const std::string &ip, int port, const std::string &address, const C &that, T (C::*getter)() const) {
-    ofxGetOscPublisher(ip, port).publishIf(condition, address, that, getter);
-}
-
-#pragma mark condition is function
-
-template <typename T>
-inline void ofxPublishOscIf(bool (*condition)(), const std::string &ip, int port, const std::string &address, T &value) {
-    ofxGetOscPublisher(ip, port).publishIf(condition, address, value);
-}
-
-template <typename T>
-inline void ofxPublishOscIf(bool (*condition)(), const std::string &ip, int port, const std::string &address, T (*getter)()) {
-    ofxGetOscPublisher(ip, port).publishIf(condition, address, getter);
-}
-
-template <typename T, typename C>
-inline void ofxPublishOscIf(bool (*condition)(), const std::string &ip, int port, const std::string &address, C *that, T (C::*getter)()) {
-    ofxGetOscPublisher(ip, port).publishIf(condition, address, *that, getter);
-}
-
-template <typename T, typename C>
-inline void ofxPublishOscIf(bool (*condition)(), const std::string &ip, int port, const std::string &address, const C * const that, T (C::*getter)() const) {
-    ofxGetOscPublisher(ip, port).publishIf(condition, address, *that, getter);
-}
-
-template <typename T, typename C>
-inline void ofxPublishOscIf(bool (*condition)(), const std::string &ip, int port, const std::string &address, C &that, T (C::*getter)()) {
-    ofxGetOscPublisher(ip, port).publishIf(condition, address, that, getter);
-}
-
-template <typename T, typename C>
-inline void ofxPublishOscIf(bool (*condition)(), const std::string &ip, int port, const std::string &address, const C &that, T (C::*getter)() const) {
+template <typename ConditionValueRefOrFunction, typename ObjectPtrOrRef, typename GetterMethod>
+inline void ofxPublishOscIf(ConditionValueRefOrFunction &condition, const std::string &ip, int port, const std::string &address, ObjectPtrOrRef &that, GetterMethod getter) {
     ofxGetOscPublisher(ip, port).publishIf(condition, address, that, getter);
 }
 
 #pragma mark condition is method
 
-template <typename T, typename Condition>
-inline void ofxPublishOscIf(Condition *condition, bool (Condition::*method)(), const std::string &ip, int port, const std::string &address, T &value) {
-    ofxGetOscPublisher(ip, port).publishIf(*condition, method, address, value);
-}
-
-template <typename T, typename Condition>
-inline void ofxPublishOscIf(Condition &condition, bool (Condition::*method)(), const std::string &ip, int port, const std::string &address, T &value) {
+template <typename ConditionObjectPtrOrRef, typename ConditionMethodReturnsBool, typename ValueRefOrFunction>
+inline void ofxPublishOscIf(ConditionObjectPtrOrRef &condition, ConditionMethodReturnsBool method, const std::string &ip, int port, const std::string &address, ValueRefOrFunction &value) {
     ofxGetOscPublisher(ip, port).publishIf(condition, method, address, value);
 }
 
-template <typename T, typename Condition>
-inline void ofxPublishOscIf(Condition *condition, bool (Condition::*method)(), const std::string &ip, int port, const std::string &address, T (*getter)()) {
-    ofxGetOscPublisher(ip, port).publishIf(*condition, method, address, getter);
-}
-
-template <typename T, typename Condition>
-inline void ofxPublishOscIf(Condition &condition, bool (Condition::*method)(), const std::string &ip, int port, const std::string &address, T (*getter)()) {
-    ofxGetOscPublisher(ip, port).publishIf(condition, method, address, getter);
-}
-
-template <typename T, typename C, typename Condition>
-inline void ofxPublishOscIf(Condition *condition, bool (Condition::*method)(), const std::string &ip, int port, const std::string &address, C *that, T (C::*getter)()) {
-    ofxGetOscPublisher(ip, port).publishIf(*condition, method, address, *that, getter);
-}
-
-template <typename T, typename C, typename Condition>
-inline void ofxPublishOscIf(Condition *condition, bool (Condition::*method)(), const std::string &ip, int port, const std::string &address, const C * const that, T (C::*getter)() const) {
-    ofxGetOscPublisher(ip, port).publishIf(*condition, method, address, *that, getter);
-}
-
-template <typename T, typename C, typename Condition>
-inline void ofxPublishOscIf(Condition &condition, bool (Condition::*method)(), const std::string &ip, int port, const std::string &address, C *that, T (C::*getter)()) {
+template <typename ConditionObjectPtrOrRef, typename ConditionMethodReturnsBool, typename ObjectRefOrPtr, typename GetterMethod>
+inline void ofxPublishOscIf(ConditionObjectPtrOrRef &condition, ConditionMethodReturnsBool method, const std::string &ip, int port, const std::string &address, ObjectRefOrPtr &that, GetterMethod getter) {
     ofxGetOscPublisher(ip, port).publishIf(condition, method, address, *that, getter);
-}
-
-template <typename T, typename C, typename Condition>
-inline void ofxPublishOscIf(Condition &condition, bool (Condition::*method)(), const std::string &ip, int port, const std::string &address, const C * const that, T (C::*getter)() const) {
-    ofxGetOscPublisher(ip, port).publishIf(condition, method, address, *that, getter);
-}
-
-template <typename T, typename C, typename Condition>
-inline void ofxPublishOscIf(Condition *condition, bool (Condition::*method)(), const std::string &ip, int port, const std::string &address, C &that, T (C::*getter)()) {
-    ofxGetOscPublisher(ip, port).publishIf(*condition, method, address, that, getter);
-}
-
-template <typename T, typename C, typename Condition>
-inline void ofxPublishOscIf(Condition *condition, bool (Condition::*method)(), const std::string &ip, int port, const std::string &address, const C &that, T (C::*getter)() const) {
-    ofxGetOscPublisher(ip, port).publishIf(*condition, method, address, that, getter);
-}
-
-template <typename T, typename C, typename Condition>
-inline void ofxPublishOscIf(Condition &condition, bool (Condition::*method)(), const std::string &ip, int port, const std::string &address, C &that, T (C::*getter)()) {
-    ofxGetOscPublisher(ip, port).publishIf(condition, method, address, that, getter);
-}
-
-template <typename T, typename C, typename Condition>
-inline void ofxPublishOscIf(Condition &condition, bool (Condition::*method)(), const std::string &ip, int port, const std::string &address, const C &that, T (C::*getter)() const) {
-    ofxGetOscPublisher(ip, port).publishIf(condition, method, address, that, getter);
-}
-
-#pragma mark condition is const method
-
-template <typename T, typename Condition>
-inline void ofxPublishOscIf(const Condition * const condition, bool (Condition::*method)() const, const std::string &ip, int port, const std::string &address, T &value) {
-    ofxGetOscPublisher(ip, port).publishIf(*condition, method, address, value);
-}
-
-template <typename T, typename Condition>
-inline void ofxPublishOscIf(const Condition &condition, bool (Condition::*method)() const, const std::string &ip, int port, const std::string &address, T &value) {
-    ofxGetOscPublisher(ip, port).publishIf(condition, method, address, value);
-}
-
-template <typename T, typename Condition>
-inline void ofxPublishOscIf(const Condition * const condition, bool (Condition::*method)() const, const std::string &ip, int port, const std::string &address, T (*getter)()) {
-    ofxGetOscPublisher(ip, port).publishIf(*condition, method, address, getter);
-}
-
-template <typename T, typename Condition>
-inline void ofxPublishOscIf(const Condition &condition, bool (Condition::*method)() const, const std::string &ip, int port, const std::string &address, T (*getter)()) {
-    ofxGetOscPublisher(ip, port).publishIf(condition, method, address, getter);
-}
-
-template <typename T, typename C, typename Condition>
-inline void ofxPublishOscIf(const Condition * const condition, bool (Condition::*method)() const, const std::string &ip, int port, const std::string &address, C *that, T (C::*getter)()) {
-    ofxGetOscPublisher(ip, port).publishIf(*condition, method, address, *that, getter);
-}
-
-template <typename T, typename C, typename Condition>
-inline void ofxPublishOscIf(const Condition * const condition, bool (Condition::*method)() const, const std::string &ip, int port, const std::string &address, const C * const that, T (C::*getter)() const) {
-    ofxGetOscPublisher(ip, port).publishIf(*condition, method, address, *that, getter);
-}
-
-template <typename T, typename C, typename Condition>
-inline void ofxPublishOscIf(const Condition &condition, bool (Condition::*method)() const, const std::string &ip, int port, const std::string &address, C *that, T (C::*getter)()) {
-    ofxGetOscPublisher(ip, port).publishIf(condition, method, address, *that, getter);
-}
-
-template <typename T, typename C, typename Condition>
-inline void ofxPublishOscIf(const Condition &condition, bool (Condition::*method)() const, const std::string &ip, int port, const std::string &address, const C * const that, T (C::*getter)() const) {
-    ofxGetOscPublisher(ip, port).publishIf(condition, method, address, *that, getter);
-}
-
-template <typename T, typename C, typename Condition>
-inline void ofxPublishOscIf(const Condition * const condition, bool (Condition::*method)() const, const std::string &ip, int port, const std::string &address, C &that, T (C::*getter)()) {
-    ofxGetOscPublisher(ip, port).publishIf(*condition, method, address, that, getter);
-}
-
-template <typename T, typename C, typename Condition>
-inline void ofxPublishOscIf(const Condition * const condition, bool (Condition::*method)() const, const std::string &ip, int port, const std::string &address, const C &that, T (C::*getter)() const) {
-    ofxGetOscPublisher(ip, port).publishIf(*condition, method, address, that, getter);
-}
-
-template <typename T, typename C, typename Condition>
-inline void ofxPublishOscIf(const Condition &condition, bool (Condition::*method)() const, const std::string &ip, int port, const std::string &address, C &that, T (C::*getter)()) {
-    ofxGetOscPublisher(ip, port).publishIf(condition, method, address, that, getter);
-}
-
-template <typename T, typename C, typename Condition>
-inline void ofxPublishOscIf(const Condition &condition, bool (Condition::*method)() const, const std::string &ip, int port, const std::string &address, const C &that, T (C::*getter)() const) {
-    ofxGetOscPublisher(ip, port).publishIf(condition, method, address, that, getter);
 }
 
 /// \}

--- a/src/ofxOscPublisher.h
+++ b/src/ofxOscPublisher.h
@@ -21,11 +21,11 @@ namespace ofx {
     namespace {
         template <typename T>
         struct remove_reference {
-            typedef T type;
+            using type = T;
         };
         template <typename T>
         struct remove_reference<T &> {
-            typedef T type;
+            using type = T;
         };
 #define remove_ref(T) typename ofx::remove_reference<T>::type
         
@@ -45,16 +45,6 @@ namespace ofx {
 #undef define_is_integral
         
 #define type_ref(T) typename add_reference_if_non_arithmetic<T>::type
-        
-        namespace impl {
-            template <bool b, typename T>
-            struct enable {};
-            
-            template <typename T>
-            struct enable<true, T> { typedef T type;};
-        }
-        template <bool b, typename T = void>
-        struct enable : impl::enable<b, T> {};
         
         template <typename T>
         struct is_pointer {
@@ -84,10 +74,10 @@ namespace ofx {
         struct SetImplementation {
         protected:
             template <typename T>
-            inline typename enable<is_integral_and_lt_64bit<T>::value>::type set(ofxOscMessage &m, T v) const { m.addIntArg(v); }
+            inline typename std::enable_if<is_integral_and_lt_64bit<T>::value>::type set(ofxOscMessage &m, T v) const { m.addIntArg(v); }
             
             template <typename T>
-            inline typename enable<is_integral_and_geq_64bit<T>::value>::type set(ofxOscMessage &m, T v) const { m.addInt64Arg(v); }
+            inline typename std::enable_if<is_integral_and_geq_64bit<T>::value>::type set(ofxOscMessage &m, T v) const { m.addInt64Arg(v); }
             
 #define define_set_float(type) inline void set(ofxOscMessage &m, type v) const { m.addFloatArg(v); }
             define_set_float(float);
@@ -160,7 +150,7 @@ namespace ofx {
             
             virtual bool inner_condition() { return true; };
             
-            typedef std::shared_ptr<BasicCondition> Ref;
+            using Ref = std::shared_ptr<BasicCondition>;
         private:
             bool bPublishNow;
         };
@@ -205,7 +195,7 @@ namespace ofx {
             bool (T::*getter)() const;
         };
 
-        typedef BasicCondition::Ref BasicConditionRef;
+        using BasicConditionRef = BasicCondition::Ref;
         
 #pragma mark Parameter
         
@@ -361,7 +351,7 @@ namespace ofx {
 
         template <typename T, bool isCheckValue>
         struct GetterFunctionParameter : Parameter<T, isCheckValue> {
-            typedef T (*GetterFunction)();
+            using GetterFunction = T (*)();
             GetterFunctionParameter(GetterFunction getter)
             : Parameter<T, isCheckValue>(dummy)
             , getter(getter) {}
@@ -374,8 +364,8 @@ namespace ofx {
         
         template <typename Base, size_t size, bool isCheckValue>
         struct GetterFunctionParameter<Base(&)[size], isCheckValue> : Parameter<Base(&)[size], isCheckValue>  {
-            typedef Base (&T)[size];
-            typedef T (*GetterFunction)();
+            using T = Base (&)[size];
+            using GetterFunction = T (*)();
             GetterFunctionParameter(GetterFunction getter)
             : Parameter<Base[size], isCheckValue>(dummy)
             , getter(getter) {}
@@ -392,7 +382,7 @@ namespace ofx {
         
         template <typename T, typename C, bool isCheckValue>
         struct GetterParameter : Parameter<T, isCheckValue> {
-            typedef T (C::*Getter)();
+            using Getter = T (C::*)();
             
             GetterParameter(C &that, Getter getter)
             : Parameter<T, isCheckValue>(dummy)
@@ -408,8 +398,8 @@ namespace ofx {
 
         template <typename Base, size_t size, typename C, bool isCheckValue>
         struct GetterParameter<Base(&)[size], C, isCheckValue> : Parameter<Base(&)[size], isCheckValue> {
-            typedef Base (&T)[size];
-            typedef T (C::*Getter)();
+            using T = Base (&)[size];
+            using Getter = T (C::*)();
             
             GetterParameter(C &that, Getter getter)
             : Parameter<T, isCheckValue>(dummy)
@@ -429,7 +419,7 @@ namespace ofx {
         
         template <typename T, typename C, bool isCheckValue>
         struct ConstGetterParameter : Parameter<T, isCheckValue> {
-            typedef T (C::*Getter)() const;
+            using Getter = T (C::*)() const;
             
             ConstGetterParameter(const C &that, Getter getter)
             : Parameter<T, isCheckValue>(dummy)
@@ -445,8 +435,8 @@ namespace ofx {
         
         template <typename Base, size_t size, typename C, bool isCheckValue>
         struct ConstGetterParameter<Base(&)[size], C, isCheckValue> : Parameter<Base(&)[size], isCheckValue> {
-            typedef Base (&T)[size];
-            typedef T (C::*Getter)() const;
+            using T = Base (&)[size];
+            using Getter = T (C::*)() const;
             
             ConstGetterParameter(const C &that, Getter getter)
             : Parameter<T, isCheckValue>(dummy)
@@ -464,8 +454,8 @@ namespace ofx {
             Base dummy[size];
         };
 
-        typedef std::shared_ptr<AbstractParameter> ParameterRef;
-        typedef std::multimap<std::string, ParameterRef> Targets;
+        using ParameterRef = std::shared_ptr<AbstractParameter>;
+        using Targets = std::multimap<std::string, ParameterRef>;
         
         public:
         struct IP {
@@ -1008,7 +998,7 @@ namespace ofx {
                 return isRegistered() && (registeredTargets.find(address) != registeredTargets.end());
             }
             
-            typedef std::shared_ptr<OscPublisher> Ref;
+            using Ref = std::shared_ptr<OscPublisher>;
             
             static void setUseBundle(bool b) {
                 bUseBundle = b;
@@ -1051,7 +1041,7 @@ namespace ofx {
             friend class OscPublisherManager;
         };
         
-        typedef std::map<Destination, OscPublisher::Ref> OscPublishers;
+        using OscPublishers = std::map<Destination, OscPublisher::Ref>;
         
         static OscPublisherManager &getSharedInstance() {
             static OscPublisherManager *sharedInstance = new OscPublisherManager;
@@ -1082,25 +1072,25 @@ namespace ofx {
         
 #pragma mark iterator
     public:
-        typedef OscPublishers::iterator iterator;
-        typedef OscPublishers::const_iterator const_iterator;
-        typedef OscPublishers::reverse_iterator reverse_iterator;
-        typedef OscPublishers::const_reverse_iterator const_reverse_iterator;
+        using iterator = OscPublishers::iterator;
+        using const_iterator = OscPublishers::const_iterator;
+        using reverse_iterator = OscPublishers::reverse_iterator;
+        using const_reverse_iterator = OscPublishers::const_reverse_iterator;
         
         iterator begin() { return publishers.begin(); }
         iterator end() { return publishers.end(); }
         
-        const_iterator begin() const { return publishers.begin(); }
-        const_iterator end() const { return publishers.end(); }
-        const_iterator cbegin() const { return publishers.begin(); }
-        const_iterator cend() const { return publishers.end(); }
+        const_iterator begin() const { return publishers.cbegin(); }
+        const_iterator end() const { return publishers.cend(); }
+        const_iterator cbegin() const { return publishers.cbegin(); }
+        const_iterator cend() const { return publishers.cend(); }
         
         reverse_iterator rbegin() { return publishers.rbegin(); }
         reverse_iterator rend() { return publishers.rend(); }
         
-        const_reverse_iterator rbegin() const { return publishers.rbegin(); }
-        const_reverse_iterator rend() const { return publishers.rend(); }
-        const_reverse_iterator crbegin() const { return publishers.rbegin(); }
+        const_reverse_iterator rbegin() const { return publishers.crbegin(); }
+        const_reverse_iterator rend() const { return publishers.crend(); }
+        const_reverse_iterator crbegin() const { return publishers.crbegin(); }
         const_reverse_iterator crend() const { return publishers.crend(); }
     };
     
@@ -1112,9 +1102,9 @@ namespace ofx {
 
 #pragma mark getter
 
-typedef ofx::OscPublisherManager ofxOscPublisherManager;
-typedef ofxOscPublisherManager::OscPublisher ofxOscPublisher;
-typedef ofxOscPublisherManager::Identifier ofxOscPublisherIdentifier;
+using ofxOscPublisherManager = ofx::OscPublisherManager;
+using ofxOscPublisher = ofxOscPublisherManager::OscPublisher;
+using ofxOscPublisherIdentifier = ofxOscPublisherManager::Identifier;
 
 /// \brief get a OscPublisherManager.
 /// \returns ofxOscPublisherManager
@@ -1341,12 +1331,12 @@ inline void ofxSetPublisherUsingBundle(bool bUseBundle) {
 
 template <typename T, size_t size>
 struct array_type {
-    typedef T (&type)[size];
-    typedef type (*fun)();
+    using type = T (&)[size];
+    using fun = type (*)();
     template <typename U>
     struct meth {
-        typedef type (U::*method)();
-        typedef type (U::*const_method)() const;
+        using method = type (U::*)();
+        using const_method = type (U::*)() const;
     };
 };
 

--- a/src/ofxOscPublisher.h
+++ b/src/ofxOscPublisher.h
@@ -419,8 +419,7 @@ namespace ofx {
             , port(port) {}
             
             inline bool operator<(const Destination &rhs) const {
-                if(ip != rhs.ip) return ip < rhs.ip;
-                return port < rhs.port;
+                return (ip != rhs.ip) ? (ip < rhs.ip) : (port < rhs.port);
             }
             
             inline bool operator!=(const Destination &rhs) const {
@@ -443,8 +442,7 @@ namespace ofx {
             , address(address) {}
             
             inline bool operator<(const DestinationWithAddress &rhs) const {
-                if(destination != rhs.destination) return destination < rhs.destination;
-                return address < rhs.address;
+                return (destination != rhs.destination) ? (destination < rhs.destination) : (address < rhs.address);
             }
             
             operator Destination() const {

--- a/src/ofxOscPublisher.h
+++ b/src/ofxOscPublisher.h
@@ -417,8 +417,12 @@ namespace ofx {
             , port(port) {}
             
             inline bool operator<(const Destination &rhs) const {
-                if(ip < rhs.ip) return true;
+                if(ip != rhs.ip) return ip < rhs.ip;
                 return port < rhs.port;
+            }
+            
+            inline bool operator!=(const Destination &rhs) const {
+                return ip != rhs.ip || port != rhs.port;
             }
             
             const std::string ip;
@@ -437,7 +441,7 @@ namespace ofx {
             , address(address) {}
             
             inline bool operator<(const DestinationWithAddress &rhs) const {
-                if(destination < rhs.destination) return true;
+                if(destination != rhs.destination) return destination < rhs.destination;
                 return address < rhs.address;
             }
             

--- a/src/ofxOscPublisher.h
+++ b/src/ofxOscPublisher.h
@@ -655,7 +655,7 @@ namespace ofx {
 #pragma mark publish conditional
 #pragma mark condition is bool value ref
             
-            Identifier publishIf(bool &condition, const std::string &address,const char * const value) {
+            Identifier publishIf(bool &condition, const std::string &address, const char * const value) {
                 ParameterRef p;
                 return publishIf(condition, address, std::string(value));
             }
@@ -1139,7 +1139,7 @@ inline ofxOscPublisher &ofxGetOscPublisher(const std::string &ip, int port) {
 /// \name ofxPublishOsc
 /// \{
 
-/// \brief publish value as an OSC message with an address pattern address to ip:port every time the value has changed. 
+/// \brief publish value as an OSC message with an address pattern address to ip:port every time the value has changed.
 /// If whenValueIsChanged is set to false, then the binded value is sent every frame after App::update.
 /// template parameter T is suggested by value
 /// \param ip target ip is typed const std::string &
@@ -1149,98 +1149,24 @@ inline ofxOscPublisher &ofxGetOscPublisher(const std::string &ip, int port) {
 /// \param whenValueIsChanged if this value to false, then we send value every update
 /// \returns ofxOscPublisherIdentifier
 
-template <typename T>
-inline ofxOscPublisherIdentifier ofxPublishOsc(const std::string &ip, int port, const std::string &address, T &value, bool whenValueIsChanged = true) {
-    return ofxGetOscPublisher(ip, port).publish(address, value, whenValueIsChanged);
-}
-
-// TODO: add document
-template <typename T, typename U = typename ofx::enable<!ofx::is_pointer<T>::value>::type>
-inline ofxOscPublisherIdentifier ofxPublishOsc(const std::string &ip, int port, const std::string &address, const T &value, bool whenValueIsChanged = true) {
-    return ofxGetOscPublisher(ip, port).publish(address, value, whenValueIsChanged);
-}
-
-// TODO: add document
-inline ofxOscPublisherIdentifier ofxPublishOsc(const std::string &ip, int port, const std::string &address, const char * const value, bool whenValueIsChanged = true) {
-    return ofxGetOscPublisher(ip, port).publish(address, std::string(value), whenValueIsChanged);
-}
-
-/// \brief publish the value will be gave by function as an OSC message with an address pattern address to ip:port every time the value has changed.
-///  If whenValueIsChanged is set to false, then the binded value is sent every frame after App::update.
-/// template parameter T is suggested by value
-/// \param ip target ip is typed const std::string &
-/// \param port target port is typed int
-/// \param address osc address is typed const std::string &
-/// \param getter this function gives value, is typed T(*)()
-/// \param whenValueIsChanged if this value to false, then we send value every update
-/// \returns ofxOscPublisherIdentifier
-
-template <typename T>
-inline ofxOscPublisherIdentifier ofxPublishOsc(const std::string &ip, int port, const std::string &address, T (*getter)(), bool whenValueIsChanged = true) {
-    return ofxGetOscPublisher(ip, port).publish(address, getter, whenValueIsChanged);
+template <typename ValueRefOrGetterFunction>
+inline ofxOscPublisherIdentifier ofxPublishOsc(const std::string &ip, int port, const std::string &address, ValueRefOrGetterFunction &&valueRefOrGetterFunction, bool whenValueIsChanged = true) {
+    return ofxGetOscPublisher(ip, port).publish(address, valueRefOrGetterFunction, whenValueIsChanged);
 }
 
 /// \brief publish the value will be gave by function as an OSC message with an address pattern address to ip:port every time the value has changed.
 /// If whenValueIsChanged is set to false, then the binded value is sent every frame after App::update.
-/// template parameter T is suggested by value and U is suggested by that and getter.
+/// template parameter ObjectPtrOrRef is suggested by that, and Method is suggested by getter.
 /// \param ip target ip is typed const std::string &
 /// \param port target port is typed int
 /// \param address osc address is typed const std::string &
-/// \param that this object is typed U*, will bind with next parameter method. is called as (that->*getter)().
+/// \param that this object is typed ObjectPtrOrRef, will bind with next parameter method. is called as (that->*getter)() or (that.*getter)().
 /// \param getter this method gives value, is typed T(C::*)()
 /// \param whenValueIsChanged if this value to false, then we send value every update
 /// \returns ofxOscPublisherIdentifier
 
-template <typename T, typename C>
-inline ofxOscPublisherIdentifier ofxPublishOsc(const std::string &ip, int port, const std::string &address, C *that, T (C::*getter)(), bool whenValueIsChanged = true) {
-    return ofxGetOscPublisher(ip, port).publish(address, *that, getter, whenValueIsChanged);
-}
-
-/// \brief publish the value will be gave by function as an OSC message with an address pattern address to ip:port every time the value has changed.
-/// If whenValueIsChanged is set to false, then the binded value is sent every frame after App::update.
-/// template parameter T is suggested by value and U is suggested by that and getter.
-/// \param ip target ip is typed const std::string &
-/// \param port target port is typed int
-/// \param address osc address is typed const std::string &
-/// \param that this object is typed U*, will bind with next parameter method. is called as (that->*getter)().
-/// \param getter this method gives value, is typed T(C::*)() const
-/// \param whenValueIsChanged if this value to false, then we send value every update
-/// \returns ofxOscPublisherIdentifier
-
-template <typename T, typename C>
-inline ofxOscPublisherIdentifier ofxPublishOsc(const std::string &ip, int port, const std::string &address, const C * const that, T (C::*getter)() const, bool whenValueIsChanged = true) {
-    return ofxGetOscPublisher(ip, port).publish(address, *that, getter, whenValueIsChanged);
-}
-
-/// \brief publish the value will be gave by function as an OSC message with an address pattern address to ip:port every time the value has changed.
-/// If whenValueIsChanged is set to false, then the binded value is sent every frame after App::update.
-/// template parameter T is suggested by value and U is suggested by that and getter.
-/// \param ip target ip is typed const std::string &
-/// \param port target port is typed int
-/// \param address osc address is typed const std::string &
-/// \param that this object is typed U&, will bind with next parameter method. is called as (that.*getter)()
-/// \param getter this method gives value, is typed T(C::*)()
-/// \param whenValueIsChanged if this value to false, then we send value every update
-/// \returns ofxOscPublisherIdentifier
-
-template <typename T, typename C>
-inline ofxOscPublisherIdentifier ofxPublishOsc(const std::string &ip, int port, const std::string &address, C &that, T (C::*getter)(), bool whenValueIsChanged = true) {
-    return ofxGetOscPublisher(ip, port).publish(address, that, getter, whenValueIsChanged);
-}
-
-/// \brief publish the value will be gave by function as an OSC message with an address pattern address to ip:port every time the value has changed.
-/// If whenValueIsChanged is set to false, then the binded value is sent every frame after App::update.
-/// template parameter T is suggested by value and U is suggested by that and getter.
-/// \param ip target ip is typed const std::string &
-/// \param port target port is typed int
-/// \param address osc address is typed const std::string &
-/// \param that this object is typed U&, will bind with next parameter method. is called as (that.*getter)()
-/// \param getter this method gives value, is typed T(C::*)() const
-/// \param whenValueIsChanged if this value to false, then we send value every update
-/// \returns ofxOscPublisherIdentifier
-
-template <typename T, typename C>
-inline ofxOscPublisherIdentifier ofxPublishOsc(const std::string &ip, int port, const std::string &address, const C &that, T (C::*getter)() const, bool whenValueIsChanged = true) {
+template <typename ObjectPtrOrRef, typename Method>
+inline ofxOscPublisherIdentifier ofxPublishOsc(const std::string &ip, int port, const std::string &address, ObjectPtrOrRef &&that, Method getter, bool whenValueIsChanged = true) {
     return ofxGetOscPublisher(ip, port).publish(address, that, getter, whenValueIsChanged);
 }
 
@@ -1293,25 +1219,25 @@ inline void ofxPublishOsc(const std::initializer_list<ofxOscPublisherManager::De
 /// \param whenValueIsChanged if this value to false, then we send value every update
 /// \returns ofxOscPublisherIdentifier
 
-template <typename ConditionValueRefOrFunction, typename ValueRefOrFunction>
-inline ofxOscPublisherIdentifier ofxPublishOscIf(ConditionValueRefOrFunction &condition, const std::string &ip, int port, const std::string &address, ValueRefOrFunction &value) {
-    return ofxGetOscPublisher(ip, port).publishIf(condition, address, value);
+template <typename ConditionValueRef, typename ValueRefOrGetterFunction>
+inline ofxOscPublisherIdentifier ofxPublishOscIf(ConditionValueRef &&condition, const std::string &ip, int port, const std::string &address, ValueRefOrGetterFunction &&valueRefOrGetterFunction) {
+    return ofxGetOscPublisher(ip, port).publishIf(condition, address, valueRefOrGetterFunction);
 }
 
-template <typename ConditionValueRefOrFunction, typename ObjectPtrOrRef, typename GetterMethod>
-inline ofxOscPublisherIdentifier ofxPublishOscIf(ConditionValueRefOrFunction &condition, const std::string &ip, int port, const std::string &address, ObjectPtrOrRef &that, GetterMethod getter) {
+template <typename ConditionValueRef, typename ObjectPtrOrRef, typename GetterMethod>
+inline ofxOscPublisherIdentifier ofxPublishOscIf(ConditionValueRef &&condition, const std::string &ip, int port, const std::string &address, ObjectPtrOrRef &&that, GetterMethod getter) {
     return ofxGetOscPublisher(ip, port).publishIf(condition, address, that, getter);
 }
 
 #pragma mark condition is method
 
 template <typename ConditionObjectPtrOrRef, typename ConditionMethodReturnsBool, typename ValueRefOrFunction>
-inline ofxOscPublisherIdentifier ofxPublishOscIf(ConditionObjectPtrOrRef &condition, ConditionMethodReturnsBool method, const std::string &ip, int port, const std::string &address, ValueRefOrFunction &value) {
-    return ofxGetOscPublisher(ip, port).publishIf(condition, method, address, value);
+inline ofxOscPublisherIdentifier ofxPublishOscIf(ConditionObjectPtrOrRef &&condition, ConditionMethodReturnsBool method, const std::string &ip, int port, const std::string &address, ValueRefOrFunction &&valueRefOrGetterFunction) {
+    return ofxGetOscPublisher(ip, port).publishIf(condition, method, address, valueRefOrGetterFunction);
 }
 
-template <typename ConditionObjectPtrOrRef, typename ConditionMethodReturnsBool, typename ObjectRefOrPtr, typename GetterMethod>
-inline ofxOscPublisherIdentifier ofxPublishOscIf(ConditionObjectPtrOrRef &condition, ConditionMethodReturnsBool method, const std::string &ip, int port, const std::string &address, ObjectRefOrPtr &that, GetterMethod getter) {
+template <typename ConditionObjectPtrOrRef, typename ConditionMethodReturnsBool, typename ObjectPtrOrRef, typename GetterMethod>
+inline ofxOscPublisherIdentifier ofxPublishOscIf(ConditionObjectPtrOrRef &&condition, ConditionMethodReturnsBool method, const std::string &ip, int port, const std::string &address, ObjectPtrOrRef &&that, GetterMethod getter) {
     return ofxGetOscPublisher(ip, port).publishIf(condition, method, address, *that, getter);
 }
 
@@ -1351,33 +1277,13 @@ inline void ofxUnpublishOsc() {
 /// \name ofxRegisterPublishingOsc
 /// \{
 
-template <typename T>
-inline ofxOscPublisherIdentifier ofxRegisterPublishingOsc(const std::string &ip, int port, const std::string &address, T &value) {
-    return ofxGetOscPublisher(ip, port).doRegister(address, value);
+template <typename ValueOrGetterFunctionType>
+inline ofxOscPublisherIdentifier ofxRegisterPublishingOsc(const std::string &ip, int port, const std::string &address, ValueOrGetterFunctionType &&valueOrGetterFunction) {
+    return ofxGetOscPublisher(ip, port).doRegister(address, valueOrGetterFunction);
 }
 
-template <typename T>
-inline ofxOscPublisherIdentifier ofxRegisterPublishingOsc(const std::string &ip, int port, const std::string &address, T (*getter)()) {
-    return ofxGetOscPublisher(ip, port).doRegister(address, getter);
-}
-
-template <typename T, typename C>
-inline ofxOscPublisherIdentifier ofxRegisterPublishingOsc(const std::string &ip, int port, const std::string &address, C *that, T (C::*getter)()) {
-    return ofxGetOscPublisher(ip, port).doRegister(address, that, getter);
-}
-
-template <typename T, typename C>
-inline ofxOscPublisherIdentifier ofxRegisterPublishingOsc(const std::string &ip, int port, const std::string &address, const C * const that, T (C::*getter)() const) {
-    return ofxGetOscPublisher(ip, port).doRegister(address, that, getter);
-}
-
-template <typename T, typename C>
-inline ofxOscPublisherIdentifier ofxRegisterPublishingOsc(const std::string &ip, int port, const std::string &address, C &that, T (C::*getter)()) {
-    return ofxGetOscPublisher(ip, port).doRegister(address, that, getter);
-}
-
-template <typename T, typename C>
-inline ofxOscPublisherIdentifier ofxRegisterPublishingOsc(const std::string &ip, int port, const std::string &address, const C &that, T (C::*getter)() const) {
+template <typename ObjectPtrOrRef, typename GetterMethod>
+inline ofxOscPublisherIdentifier ofxRegisterPublishingOsc(const std::string &ip, int port, const std::string &address, ObjectPtrOrRef &&that, GetterMethod &&getter) {
     return ofxGetOscPublisher(ip, port).doRegister(address, that, getter);
 }
 

--- a/src/ofxOscPublisher.h
+++ b/src/ofxOscPublisher.h
@@ -404,7 +404,7 @@ namespace ofx {
                 return ip < rhs.ip;
             }
             
-            const std::string ip;
+            std::string ip;
         private:
             IP();
         };
@@ -426,8 +426,8 @@ namespace ofx {
                 return ip != rhs.ip || port != rhs.port;
             }
             
-            const std::string ip;
-            const int port;
+            std::string ip;
+            int port;
         private:
             Destination();
         };
@@ -453,22 +453,32 @@ namespace ofx {
                 return destination;
             }
             
-            const Destination destination;
-            const std::string address;
+            Destination destination;
+            std::string address;
         private:
             DestinationWithAddress();
         };
 
         class Identifier {
-            const std::string address;
-            const ParameterRef ref;
+            std::string address;
+            ParameterRef ref;
+            Destination key;
+            
+            void invalidation() {
+                address = "";
+                ref = nullptr;
+                key = Destination();
+            }
         public:
+            Identifier() {}
             Identifier(const std::string &address, const ParameterRef &ref, const Destination &key)
             : address(address)
             , ref(ref)
             , key(key) {}
-            Destination key;
             
+            const Destination &getKey() const { return key; };
+            bool isValid() const { return static_cast<bool>(ref); }
+
             friend class OscPublisher;
         };
 

--- a/src/ofxOscPublisher.h
+++ b/src/ofxOscPublisher.h
@@ -821,6 +821,13 @@ namespace ofx {
 typedef ofx::OscPublisherManager ofxOscPublisherManager;
 typedef ofxOscPublisherManager::OscPublisher ofxOscPublisher;
 
+/// \brief get a OscPublisherManager.
+/// \returns ofxOscPublisherManager
+
+inline ofxOscPublisherManager &ofxGetOscPublisherManager() {
+    return ofxOscPublisherManager::getSharedInstance();
+}
+
 /// \brief get a OscPublisher.
 /// \param ip target ip is typed const std::string &
 /// \param port target port is typed int
@@ -1189,6 +1196,15 @@ inline void ofxUnpublishOsc(const std::string &ip, int port) {
     ofxGetOscPublisher(ip, port).unpublish();
 }
 
+inline void ofxUnpublishOsc() {
+    ofxOscPublisherManager &manager = ofxGetOscPublisherManager();
+    ofxOscPublisherManager::iterator it  = manager.begin(),
+                                     end = manager.end();
+    for(; it != end; it++) {
+        it->second->unpublish();
+    }
+}
+
 /// \}
 
 #pragma mark register
@@ -1239,6 +1255,14 @@ inline void ofxUnregisterPublishingOsc(const std::string &ip, int port) {
     ofxGetOscPublisher(ip, port).unregister();
 }
 
+inline void ofxUnregisterPublishingOsc() {
+    ofxOscPublisherManager &manager = ofxGetOscPublisherManager();
+    ofxOscPublisherManager::iterator it  = manager.begin(),
+                                     end = manager.end();
+    for(; it != end; it++) {
+        it->second->unregister();
+    }
+}
 #pragma mark using bundle option
 
 inline void ofxSetPublisherUsingBundle(bool bUseBundle) {

--- a/src/ofxOscPublisher.h
+++ b/src/ofxOscPublisher.h
@@ -389,7 +389,8 @@ namespace ofx {
 
         typedef std::shared_ptr<AbstractParameter> ParameterRef;
         typedef std::map<std::string, ParameterRef> Targets;
-
+        
+        public:
         struct IP {
             IP(const IP &ip)
             : ip(ip.ip) {}

--- a/src/ofxOscPublisher.h
+++ b/src/ofxOscPublisher.h
@@ -94,9 +94,7 @@ namespace ofx {
             define_set_float(double);
 #undef define_set_float
             inline void set(ofxOscMessage &m, const std::string &v) const { m.addStringArg(v); }
-#if ENABLE_OF_BUFFER
             inline void set(ofxOscMessage &m, const ofBuffer &v) const { m.addBlobArg(v); };
-#endif
             template <typename PixType>
             inline void set(ofxOscMessage &m, const ofColor_<PixType> &v) const {  setVec<4>(m, v); }
             inline void set(ofxOscMessage &m, const ofVec2f &v) const { setVec<2>(m, v); }
@@ -1170,8 +1168,6 @@ inline ofxOscPublisherIdentifier ofxPublishOsc(const std::string &ip, int port, 
     return ofxGetOscPublisher(ip, port).publish(address, that, getter, whenValueIsChanged);
 }
 
-#if ENABLE_CPP11
-
 template <typename ... Args>
 inline void ofxPublishOsc(const std::string &ip, const std::initializer_list<int> ports, Args & ... args) {
     for(auto port : ports) {
@@ -1199,8 +1195,6 @@ inline void ofxPublishOsc(const std::initializer_list<ofxOscPublisherManager::De
         ofxPublishOsc(target.destination.ip, target.destination.port, target.address, args ...);
     }
 }
-
-#endif
 
 /// \}
 

--- a/src/ofxOscPublisher.h
+++ b/src/ofxOscPublisher.h
@@ -279,7 +279,6 @@ namespace ofx {
             }
             
             virtual Base (&get())[size] { return t; }
-        protected:
             Base (&t)[size];
             Base old[size];
         };

--- a/src/ofxOscPublisher.h
+++ b/src/ofxOscPublisher.h
@@ -75,7 +75,7 @@ namespace ofx {
             define_set_float(float);
             define_set_float(double);
 #undef define_set_float
-            inline void set(ofxOscMessage &m, const string &v) const { m.addStringArg(v); }
+            inline void set(ofxOscMessage &m, const std::string &v) const { m.addStringArg(v); }
 #if ENABLE_OF_BUFFER
             inline void set(ofxOscMessage &m, const ofBuffer &v) const { m.addBlobArg(v); };
 #endif
@@ -143,7 +143,7 @@ namespace ofx {
             
             virtual bool inner_condition() { return true; };
             
-            typedef shared_ptr<BasicCondition> Ref;
+            typedef std::shared_ptr<BasicCondition> Ref;
         private:
             bool bPublishNow;
         };
@@ -194,7 +194,7 @@ namespace ofx {
         
         struct AbstractParameter {
             AbstractParameter() : condition(new BasicCondition) {}
-            virtual bool setMessage(ofxOscMessage &m, const string &address) = 0;
+            virtual bool setMessage(ofxOscMessage &m, const std::string &address) = 0;
             void setCondition(BasicConditionRef ref) { condition = ref; };
             
             inline void setEnablePublish(bool bEnablePublish) { condition->setEnablePublish(bEnablePublish); };
@@ -212,7 +212,7 @@ namespace ofx {
             Parameter(T &t)
             : t(t) {}
             
-            virtual bool setMessage(ofxOscMessage &m, const string &address) {
+            virtual bool setMessage(ofxOscMessage &m, const std::string &address) {
                 if(!canPublish() || !isChanged()) return false;
                 m.setAddress(address);
                 set(m, get());
@@ -248,7 +248,7 @@ namespace ofx {
             : t(t) { for(size_t i = 0; i < size; i++) old[i] = t[i]; }
             virtual ~Parameter() { };
             
-            virtual bool setMessage(ofxOscMessage &m, const string &address) {
+            virtual bool setMessage(ofxOscMessage &m, const std::string &address) {
                 if(!canPublish() || !isChanged()) return false;
                 m.setAddress(address);
                 set(m, get());
@@ -384,9 +384,9 @@ namespace ofx {
             Base dummy[size];
         };
 
-        typedef shared_ptr<AbstractParameter> ParameterRef;
-        typedef pair<string, int> SenderKey;
-        typedef map<string, ParameterRef> Targets;
+        typedef std::shared_ptr<AbstractParameter> ParameterRef;
+        typedef std::pair<std::string, int> SenderKey;
+        typedef std::map<std::string, ParameterRef> Targets;
         
     public:
         class OscPublisher {
@@ -394,16 +394,16 @@ namespace ofx {
 
 #pragma mark publish
             
-            inline void publish(const string &address, ParameterRef ref) {
+            inline void publish(const std::string &address, ParameterRef ref) {
                 if(targets.find(address) == targets.end()) {
-                    targets.insert(make_pair(address, ref));
+                    targets.insert(std::make_pair(address, ref));
                 } else {
                     targets[address] = ref;
                 }
             }
             
             template <typename T>
-            void publish(const string &address, T &value, bool whenValueIsChanged = true) {
+            void publish(const std::string &address, T &value, bool whenValueIsChanged = true) {
                 ParameterRef p;
                 if(whenValueIsChanged) p = ParameterRef(new Parameter<T, true>(value));
                 else                   p = ParameterRef(new Parameter<T, false>(value));
@@ -411,7 +411,7 @@ namespace ofx {
             }
             
             template <typename T>
-            void publish(const string &address, T (*getter)(), bool whenValueIsChanged = true) {
+            void publish(const std::string &address, T (*getter)(), bool whenValueIsChanged = true) {
                 ParameterRef p;
                 if(whenValueIsChanged) p = ParameterRef(new GetterFunctionParameter<T, true>(getter));
                 else                   p = ParameterRef(new GetterFunctionParameter<T, false>(getter));
@@ -419,7 +419,7 @@ namespace ofx {
             }
 
             template <typename T, typename C>
-            void publish(const string &address, C &that, T (C::*getter)(), bool whenValueIsChanged = true) {
+            void publish(const std::string &address, C &that, T (C::*getter)(), bool whenValueIsChanged = true) {
                 ParameterRef p;
                 if(whenValueIsChanged) p = ParameterRef(new GetterParameter<T, C, true>(that, getter));
                 else                   p = ParameterRef(new GetterParameter<T, C, false>(that, getter));
@@ -427,7 +427,7 @@ namespace ofx {
             }
             
             template <typename T, typename C>
-            void publish(const string &address, const C &that, T (C::*getter)() const, bool whenValueIsChanged = true) {
+            void publish(const std::string &address, const C &that, T (C::*getter)() const, bool whenValueIsChanged = true) {
                 ParameterRef p;
                 if(whenValueIsChanged) p = ParameterRef(new ConstGetterParameter<T, C, true>(that, getter));
                 else                   p = ParameterRef(new ConstGetterParameter<T, C, false>(that, getter));
@@ -438,126 +438,126 @@ namespace ofx {
 #pragma mark condition is bool value ref
             
             template <typename T>
-            void publishIf(bool &condition, const string &address, T &value) {
+            void publishIf(bool &condition, const std::string &address, T &value) {
                 ParameterRef p = ParameterRef(new Parameter<T, false>(value));
-                p->setCondition(shared_ptr<BasicCondition>(new ConditionRef(condition)));
+                p->setCondition(std::shared_ptr<BasicCondition>(new ConditionRef(condition)));
                 publish(address, p);
             }
 
             template <typename T>
-            void publishIf(bool &condition, const string &address, T (*getter)()) {
+            void publishIf(bool &condition, const std::string &address, T (*getter)()) {
                 ParameterRef p = ParameterRef(new GetterFunctionParameter<T, false>(getter));
-                p->setCondition(shared_ptr<BasicCondition>(new ConditionRef(condition)));
+                p->setCondition(std::shared_ptr<BasicCondition>(new ConditionRef(condition)));
                 publish(address, p);
             }
             
             template <typename T, typename C>
-            void publishIf(bool &condition, const string &address, C &that, T (C::*getter)()) {
+            void publishIf(bool &condition, const std::string &address, C &that, T (C::*getter)()) {
                 ParameterRef p = ParameterRef(new GetterParameter<T, C, false>(that, getter));
-                p->setCondition(shared_ptr<BasicCondition>(new ConditionRef(condition)));
+                p->setCondition(std::shared_ptr<BasicCondition>(new ConditionRef(condition)));
                 publish(address, p);
             }
 
             template <typename T, typename C>
-            void publishIf(bool &condition, const string &address, const C &that, T (C::*getter)() const) {
+            void publishIf(bool &condition, const std::string &address, const C &that, T (C::*getter)() const) {
                 ParameterRef p = ParameterRef(new ConstGetterParameter<T, C, false>(that, getter));
-                p->setCondition(shared_ptr<BasicCondition>(new ConditionRef(condition)));
+                p->setCondition(std::shared_ptr<BasicCondition>(new ConditionRef(condition)));
                 publish(address, p);
             }
             
 #pragma mark condition is function
             
             template <typename T>
-            void publishIf(bool (*condition)(), const string &address, T &value) {
+            void publishIf(bool (*condition)(), const std::string &address, T &value) {
                 ParameterRef p = ParameterRef(new Parameter<T, false>(value));
-                p->setCondition(shared_ptr<BasicCondition>(new ConditionFunction(condition)));
+                p->setCondition(std::shared_ptr<BasicCondition>(new ConditionFunction(condition)));
                 publish(address, p);
             }
             
             template <typename T>
-            void publishIf(bool (*condition)(), const string &address, T (*getter)()) {
+            void publishIf(bool (*condition)(), const std::string &address, T (*getter)()) {
                 ParameterRef p = ParameterRef(new GetterFunctionParameter<T, false>(getter));
-                p->setCondition(shared_ptr<BasicCondition>(new ConditionFunction(condition)));
+                p->setCondition(std::shared_ptr<BasicCondition>(new ConditionFunction(condition)));
                 publish(address, p);
             }
             
             template <typename T, typename C>
-            void publishIf(bool (*condition)(), const string &address, C &that, T (C::*getter)()) {
+            void publishIf(bool (*condition)(), const std::string &address, C &that, T (C::*getter)()) {
                 ParameterRef p = ParameterRef(new GetterParameter<T, C, false>(that, getter));
-                p->setCondition(shared_ptr<BasicCondition>(new ConditionFunction(condition)));
+                p->setCondition(std::shared_ptr<BasicCondition>(new ConditionFunction(condition)));
                 publish(address, p);
             }
 
             template <typename T, typename C>
-            void publishIf(bool (*condition)(), const string &address, const C &that, T (C::*getter)() const) {
+            void publishIf(bool (*condition)(), const std::string &address, const C &that, T (C::*getter)() const) {
                 ParameterRef p = ParameterRef(new ConstGetterParameter<T, C, false>(that, getter));
-                p->setCondition(shared_ptr<BasicCondition>(new ConditionFunction(condition)));
+                p->setCondition(std::shared_ptr<BasicCondition>(new ConditionFunction(condition)));
                 publish(address, p);
             }
             
 #pragma mark condition is method
             
             template <typename T, typename Condition>
-            void publishIf(Condition &condition, bool (Condition::*method)(), const string &address, T &value) {
+            void publishIf(Condition &condition, bool (Condition::*method)(), const std::string &address, T &value) {
                 ParameterRef p = ParameterRef(new Parameter<T, true>(value));
-                p->setCondition(shared_ptr<BasicCondition>(new ConditionMethod<Condition>(condition, method)));
+                p->setCondition(std::shared_ptr<BasicCondition>(new ConditionMethod<Condition>(condition, method)));
                 publish(address, p);
             }
             
             template <typename T, typename Condition>
-            void publishIf(Condition &condition, bool (Condition::*method)(), const string &address, T (*getter)()) {
+            void publishIf(Condition &condition, bool (Condition::*method)(), const std::string &address, T (*getter)()) {
                 ParameterRef p = ParameterRef(new GetterFunctionParameter<T, true>(getter));
-                p->setCondition(shared_ptr<BasicCondition>(new ConditionMethod<Condition>(condition, method)));
+                p->setCondition(std::shared_ptr<BasicCondition>(new ConditionMethod<Condition>(condition, method)));
                 publish(address, p);
             }
             
             template <typename T, typename C, typename Condition>
-            void publishIf(Condition &condition, bool (Condition::*method)(), const string &address, C &that, T (C::*getter)()) {
+            void publishIf(Condition &condition, bool (Condition::*method)(), const std::string &address, C &that, T (C::*getter)()) {
                 ParameterRef p = ParameterRef(new GetterParameter<T, C, true>(that, getter));
-                p->setCondition(shared_ptr<BasicCondition>(new ConditionMethod<Condition>(condition, method)));
+                p->setCondition(std::shared_ptr<BasicCondition>(new ConditionMethod<Condition>(condition, method)));
                 publish(address, p);
             }
             
             template <typename T, typename C, typename Condition>
-            void publishIf(Condition &condition, bool (Condition::*method)(), const string &address, const C &that, T (C::*getter)() const) {
+            void publishIf(Condition &condition, bool (Condition::*method)(), const std::string &address, const C &that, T (C::*getter)() const) {
                 ParameterRef p = ParameterRef(new ConstGetterParameter<T, C, true>(that, getter));
-                p->setCondition(shared_ptr<BasicCondition>(new ConditionMethod<Condition>(condition, method)));
+                p->setCondition(std::shared_ptr<BasicCondition>(new ConditionMethod<Condition>(condition, method)));
                 publish(address, p);
             }
             
 #pragma mark condition is const method
             
             template <typename T, typename Condition>
-            void publishIf(const Condition &condition, bool (Condition::*method)() const, const string &address, T &value) {
+            void publishIf(const Condition &condition, bool (Condition::*method)() const, const std::string &address, T &value) {
                 ParameterRef p = ParameterRef(new Parameter<T, true>(value));
-                p->setCondition(shared_ptr<BasicCondition>(new ConstConditionMethod<Condition>(condition, method)));
+                p->setCondition(std::shared_ptr<BasicCondition>(new ConstConditionMethod<Condition>(condition, method)));
                 publish(address, p);
             }
             
             template <typename T, typename Condition>
-            void publishIf(const Condition &condition, bool (Condition::*method)() const, const string &address, T (*getter)()) {
+            void publishIf(const Condition &condition, bool (Condition::*method)() const, const std::string &address, T (*getter)()) {
                 ParameterRef p = ParameterRef(new GetterFunctionParameter<T, true>(getter));
-                p->setCondition(shared_ptr<BasicCondition>(new ConstConditionMethod<Condition>(condition, method)));
+                p->setCondition(std::shared_ptr<BasicCondition>(new ConstConditionMethod<Condition>(condition, method)));
                 publish(address, p);
             }
             
             template <typename T, typename C, typename Condition>
-            void publishIf(const Condition &condition, bool (Condition::*method)() const, const string &address, C &that, T (C::*getter)()) {
+            void publishIf(const Condition &condition, bool (Condition::*method)() const, const std::string &address, C &that, T (C::*getter)()) {
                 ParameterRef p = ParameterRef(new GetterParameter<T, C, true>(that, getter));
-                p->setCondition(shared_ptr<BasicCondition>(new ConstConditionMethod<Condition>(condition, method)));
+                p->setCondition(std::shared_ptr<BasicCondition>(new ConstConditionMethod<Condition>(condition, method)));
                 publish(address, p);
             }
             
             template <typename T, typename C, typename Condition>
-            void publishIf(const Condition &condition, bool (Condition::*method)() const, const string &address, const C &that, T (C::*getter)() const) {
+            void publishIf(const Condition &condition, bool (Condition::*method)() const, const std::string &address, const C &that, T (C::*getter)() const) {
                 ParameterRef p = ParameterRef(new ConstGetterParameter<T, C, true>(that, getter));
-                p->setCondition(shared_ptr<BasicCondition>(new ConstConditionMethod<Condition>(condition, method)));
+                p->setCondition(std::shared_ptr<BasicCondition>(new ConstConditionMethod<Condition>(condition, method)));
                 publish(address, p);
             }
             
 #pragma mark unpublish
             
-            void unpublish(const string &address) {
+            void unpublish(const std::string &address) {
                 if(targets.find(address) == targets.end()) targets.erase(address);
             }
             
@@ -567,47 +567,47 @@ namespace ofx {
 
 #pragma mark stop publish temporary
             
-            void stopPublishTemporary(const string &address) {
+            void stopPublishTemporary(const std::string &address) {
                 if(isPublished(address)) targets[address]->setEnablePublish(false);
             }
             
-            void resumePublish(const string &address) {
+            void resumePublish(const std::string &address) {
                 if(isPublished(address)) targets[address]->setEnablePublish(true);
             }
             
 #pragma mark doRegister
             
-            inline void doRegister(const string &address, ParameterRef ref) {
+            inline void doRegister(const std::string &address, ParameterRef ref) {
                 if(registeredTargets.find(address) == registeredTargets.end()) {
-                    registeredTargets.insert(make_pair(address, ref));
+                    registeredTargets.insert(std::make_pair(address, ref));
                 } else {
                     registeredTargets[address] = ref;
                 }
             }
             
             template <typename T>
-            void doRegister(const string &address, T &value) {
+            void doRegister(const std::string &address, T &value) {
                 doRegister(address, ParameterRef(new Parameter<T, false>(value)));
             }
             
             template <typename T>
-            void doRegister(const string &address, T (*getter)()) {
+            void doRegister(const std::string &address, T (*getter)()) {
                 doRegister(address, ParameterRef(new GetterFunctionParameter<T, false>(getter)));
             }
             
             template <typename T, typename C>
-            void doRegister(const string &address, C &that, T (C::*getter)()) {
+            void doRegister(const std::string &address, C &that, T (C::*getter)()) {
                 doRegister(address, ParameterRef(new GetterParameter<T, C, false>(that, getter)));
             }
             
             template <typename T, typename C>
-            void doRegister(const string &address, const C &that, T (C::*getter)() const) {
+            void doRegister(const std::string &address, const C &that, T (C::*getter)() const) {
                 doRegister(address, ParameterRef(new ConstGetterParameter<T, C, false>(that, getter)));
             }
             
 #pragma mark publishRegistered
             
-            inline void publishRegistered(const string &address) {
+            inline void publishRegistered(const std::string &address) {
                 Targets::iterator it = registeredTargets.find(address);
                 if(it == registeredTargets.end()) {
                     ofLogWarning("ofxPubSubOsc") << address << " is not registered.";
@@ -619,7 +619,7 @@ namespace ofx {
             
 #pragma mark unregister
             
-            inline void unregister(const string &address) {
+            inline void unregister(const std::string &address) {
                 if(registeredTargets.find(address) == registeredTargets.end()) registeredTargets.erase(address);
             }
             
@@ -633,11 +633,11 @@ namespace ofx {
                 return !targets.empty();
             }
             
-            inline bool isPublished(const string &address) const {
+            inline bool isPublished(const std::string &address) const {
                 return isPublished() && (targets.find(address) != targets.end());
             }
             
-            inline bool isEnabled(const string &address) const {
+            inline bool isEnabled(const std::string &address) const {
                 return isPublished(address) && targets.at(address)->isPublishNow();
             }
             
@@ -645,11 +645,11 @@ namespace ofx {
                 return !registeredTargets.empty();
             }
             
-            inline bool isRegistered(const string &address) const {
+            inline bool isRegistered(const std::string &address) const {
                 return isRegistered() && (registeredTargets.find(address) != registeredTargets.end());
             }
             
-            typedef shared_ptr<OscPublisher> Ref;
+            typedef std::shared_ptr<OscPublisher> Ref;
             
             static void setUseBundle(bool b) {
                 bUseBundle = b;
@@ -696,17 +696,17 @@ namespace ofx {
             return *sharedInstance;
         }
         
-        static OscPublisher &getOscPublisher(const string &ip, int port) {
+        static OscPublisher &getOscPublisher(const std::string &ip, int port) {
             OscPublishers &publishers = getSharedInstance().publishers;
             SenderKey key(ip, port);
             if(publishers.find(key) == publishers.end()) {
-                publishers.insert(make_pair(key, OscPublisher::Ref(new OscPublisher(key))));
+                publishers.insert(std::make_pair(key, OscPublisher::Ref(new OscPublisher(key))));
             }
             return *(publishers[key].get());
         }
         
     private:
-        typedef map<SenderKey, OscPublisher::Ref> OscPublishers;
+        typedef std::map<SenderKey, OscPublisher::Ref> OscPublishers;
         void update(ofEventArgs &args) {
             for(OscPublishers::iterator it = publishers.begin(); it != publishers.end(); ++it) {
                 it->second->update();
@@ -733,11 +733,11 @@ typedef ofx::OscPublisherManager ofxOscPublisherManager;
 typedef ofxOscPublisherManager::OscPublisher ofxOscPublisher;
 
 /// \brief get a OscPublisher.
-/// \param ip target ip is typed const string &
+/// \param ip target ip is typed const std::string &
 /// \param port target port is typed int
 /// \returns ofxOscPublisher binded to ip & port
 
-inline ofxOscPublisher &ofxGetOscPublisher(const string &ip, int port) {
+inline ofxOscPublisher &ofxGetOscPublisher(const std::string &ip, int port) {
     return ofxOscPublisherManager::getOscPublisher(ip, port);
 }
 
@@ -749,94 +749,94 @@ inline ofxOscPublisher &ofxGetOscPublisher(const string &ip, int port) {
 /// \brief publish value as an OSC message with an address pattern address to ip:port every time the value has changed. 
 /// If whenValueIsChanged is set to false, then the binded value is sent every frame after App::update.
 /// template parameter T is suggested by value
-/// \param ip target ip is typed const string &
+/// \param ip target ip is typed const std::string &
 /// \param port target port is typed int
-/// \param address osc address is typed const string &
+/// \param address osc address is typed const std::string &
 /// \param value reference of value is typed T &
 /// \param whenValueIsChanged if this value to false, then we send value every update
 /// \returns void
 
 template <typename T>
-inline void ofxPublishOsc(const string &ip, int port, const string &address, T &value, bool whenValueIsChanged = true) {
+inline void ofxPublishOsc(const std::string &ip, int port, const std::string &address, T &value, bool whenValueIsChanged = true) {
     ofxGetOscPublisher(ip, port).publish(address, value, whenValueIsChanged);
 }
 
 /// \brief publish the value will be gave by function as an OSC message with an address pattern address to ip:port every time the value has changed.
 ///  If whenValueIsChanged is set to false, then the binded value is sent every frame after App::update.
 /// template parameter T is suggested by value
-/// \param ip target ip is typed const string &
+/// \param ip target ip is typed const std::string &
 /// \param port target port is typed int
-/// \param address osc address is typed const string &
+/// \param address osc address is typed const std::string &
 /// \param getter this function gives value, is typed T(*)()
 /// \param whenValueIsChanged if this value to false, then we send value every update
 /// \returns void
 
 template <typename T>
-inline void ofxPublishOsc(const string &ip, int port, const string &address, T (*getter)(), bool whenValueIsChanged = true) {
+inline void ofxPublishOsc(const std::string &ip, int port, const std::string &address, T (*getter)(), bool whenValueIsChanged = true) {
     ofxGetOscPublisher(ip, port).publish(address, getter, whenValueIsChanged);
 }
 
 /// \brief publish the value will be gave by function as an OSC message with an address pattern address to ip:port every time the value has changed.
 /// If whenValueIsChanged is set to false, then the binded value is sent every frame after App::update.
 /// template parameter T is suggested by value and U is suggested by that and getter.
-/// \param ip target ip is typed const string &
+/// \param ip target ip is typed const std::string &
 /// \param port target port is typed int
-/// \param address osc address is typed const string &
+/// \param address osc address is typed const std::string &
 /// \param that this object is typed U*, will bind with next parameter method. is called as (that->*getter)().
 /// \param getter this method gives value, is typed T(C::*)()
 /// \param whenValueIsChanged if this value to false, then we send value every update
 /// \returns void
 
 template <typename T, typename C>
-inline void ofxPublishOsc(const string &ip, int port, const string &address, C *that, T (C::*getter)(), bool whenValueIsChanged = true) {
+inline void ofxPublishOsc(const std::string &ip, int port, const std::string &address, C *that, T (C::*getter)(), bool whenValueIsChanged = true) {
     ofxGetOscPublisher(ip, port).publish(address, *that, getter, whenValueIsChanged);
 }
 
 /// \brief publish the value will be gave by function as an OSC message with an address pattern address to ip:port every time the value has changed.
 /// If whenValueIsChanged is set to false, then the binded value is sent every frame after App::update.
 /// template parameter T is suggested by value and U is suggested by that and getter.
-/// \param ip target ip is typed const string &
+/// \param ip target ip is typed const std::string &
 /// \param port target port is typed int
-/// \param address osc address is typed const string &
+/// \param address osc address is typed const std::string &
 /// \param that this object is typed U*, will bind with next parameter method. is called as (that->*getter)().
 /// \param getter this method gives value, is typed T(C::*)() const
 /// \param whenValueIsChanged if this value to false, then we send value every update
 /// \returns void
 
 template <typename T, typename C>
-inline void ofxPublishOsc(const string &ip, int port, const string &address, const C * const that, T (C::*getter)() const, bool whenValueIsChanged = true) {
+inline void ofxPublishOsc(const std::string &ip, int port, const std::string &address, const C * const that, T (C::*getter)() const, bool whenValueIsChanged = true) {
     ofxGetOscPublisher(ip, port).publish(address, *that, getter, whenValueIsChanged);
 }
 
 /// \brief publish the value will be gave by function as an OSC message with an address pattern address to ip:port every time the value has changed.
 /// If whenValueIsChanged is set to false, then the binded value is sent every frame after App::update.
 /// template parameter T is suggested by value and U is suggested by that and getter.
-/// \param ip target ip is typed const string &
+/// \param ip target ip is typed const std::string &
 /// \param port target port is typed int
-/// \param address osc address is typed const string &
+/// \param address osc address is typed const std::string &
 /// \param that this object is typed U&, will bind with next parameter method. is called as (that.*getter)()
 /// \param getter this method gives value, is typed T(C::*)()
 /// \param whenValueIsChanged if this value to false, then we send value every update
 /// \returns void
 
 template <typename T, typename C>
-inline void ofxPublishOsc(const string &ip, int port, const string &address, C &that, T (C::*getter)(), bool whenValueIsChanged = true) {
+inline void ofxPublishOsc(const std::string &ip, int port, const std::string &address, C &that, T (C::*getter)(), bool whenValueIsChanged = true) {
     ofxGetOscPublisher(ip, port).publish(address, that, getter, whenValueIsChanged);
 }
 
 /// \brief publish the value will be gave by function as an OSC message with an address pattern address to ip:port every time the value has changed.
 /// If whenValueIsChanged is set to false, then the binded value is sent every frame after App::update.
 /// template parameter T is suggested by value and U is suggested by that and getter.
-/// \param ip target ip is typed const string &
+/// \param ip target ip is typed const std::string &
 /// \param port target port is typed int
-/// \param address osc address is typed const string &
+/// \param address osc address is typed const std::string &
 /// \param that this object is typed U&, will bind with next parameter method. is called as (that.*getter)()
 /// \param getter this method gives value, is typed T(C::*)() const
 /// \param whenValueIsChanged if this value to false, then we send value every update
 /// \returns void
 
 template <typename T, typename C>
-inline void ofxPublishOsc(const string &ip, int port, const string &address, const C &that, T (C::*getter)() const, bool whenValueIsChanged = true) {
+inline void ofxPublishOsc(const std::string &ip, int port, const std::string &address, const C &that, T (C::*getter)() const, bool whenValueIsChanged = true) {
     ofxGetOscPublisher(ip, port).publish(address, that, getter, whenValueIsChanged);
 }
 /// \}
@@ -849,206 +849,206 @@ inline void ofxPublishOsc(const string &ip, int port, const string &address, con
 /// \brief publish value as an OSC message with an address pattern address to ip:port when condition is true.
 /// template parameter T is suggested by value
 /// \param condition condition of publish typed bool &
-/// \param ip target ip is typed const string &
+/// \param ip target ip is typed const std::string &
 /// \param port target port is typed int
-/// \param address osc address is typed const string &
+/// \param address osc address is typed const std::string &
 /// \param value reference of value is typed T &
 /// \param whenValueIsChanged if this value to false, then we send value every update
 /// \returns void
 
 template <typename T>
-inline void ofxPublishOscIf(bool &condition, const string &ip, int port, const string &address, T &value) {
+inline void ofxPublishOscIf(bool &condition, const std::string &ip, int port, const std::string &address, T &value) {
     ofxGetOscPublisher(ip, port).publishIf(condition, address, value);
 }
 
 /// \brief publish value will be gave by function as an OSC message with an address pattern address to ip:port when condition is true.
 /// template parameter T is suggested by value
 /// \param condition condition of publish typed bool &
-/// \param ip target ip is typed const string &
+/// \param ip target ip is typed const std::string &
 /// \param port target port is typed int
-/// \param address osc address is typed const string &
+/// \param address osc address is typed const std::string &
 /// \param getter this function gives value, is typed T(*)()
 /// \param whenValueIsChanged if this value to false, then we send value every update
 /// \returns void
 
 template <typename T>
-inline void ofxPublishOscIf(bool &condition, const string &ip, int port, const string &address, T (*getter)()) {
+inline void ofxPublishOscIf(bool &condition, const std::string &ip, int port, const std::string &address, T (*getter)()) {
     ofxGetOscPublisher(ip, port).publishIf(condition, address, getter);
 }
 
 template <typename T, typename C>
-inline void ofxPublishOscIf(bool &condition, const string &ip, int port, const string &address, C *that, T (C::*getter)()) {
+inline void ofxPublishOscIf(bool &condition, const std::string &ip, int port, const std::string &address, C *that, T (C::*getter)()) {
     ofxGetOscPublisher(ip, port).publishIf(condition, address, *that, getter);
 }
 
 template <typename T, typename C>
-inline void ofxPublishOscIf(bool &condition, const string &ip, int port, const string &address, const C * const that, T (C::*getter)() const) {
+inline void ofxPublishOscIf(bool &condition, const std::string &ip, int port, const std::string &address, const C * const that, T (C::*getter)() const) {
     ofxGetOscPublisher(ip, port).publishIf(condition, address, *that, getter);
 }
 
 template <typename T, typename C>
-inline void ofxPublishOscIf(bool &condition, const string &ip, int port, const string &address, C &that, T (C::*getter)()) {
+inline void ofxPublishOscIf(bool &condition, const std::string &ip, int port, const std::string &address, C &that, T (C::*getter)()) {
     ofxGetOscPublisher(ip, port).publishIf(condition, address, that, getter);
 }
 
 template <typename T, typename C>
-inline void ofxPublishOscIf(bool &condition, const string &ip, int port, const string &address, const C &that, T (C::*getter)() const) {
+inline void ofxPublishOscIf(bool &condition, const std::string &ip, int port, const std::string &address, const C &that, T (C::*getter)() const) {
     ofxGetOscPublisher(ip, port).publishIf(condition, address, that, getter);
 }
 
 #pragma mark condition is function
 
 template <typename T>
-inline void ofxPublishOscIf(bool (*condition)(), const string &ip, int port, const string &address, T &value) {
+inline void ofxPublishOscIf(bool (*condition)(), const std::string &ip, int port, const std::string &address, T &value) {
     ofxGetOscPublisher(ip, port).publishIf(condition, address, value);
 }
 
 template <typename T>
-inline void ofxPublishOscIf(bool (*condition)(), const string &ip, int port, const string &address, T (*getter)()) {
+inline void ofxPublishOscIf(bool (*condition)(), const std::string &ip, int port, const std::string &address, T (*getter)()) {
     ofxGetOscPublisher(ip, port).publishIf(condition, address, getter);
 }
 
 template <typename T, typename C>
-inline void ofxPublishOscIf(bool (*condition)(), const string &ip, int port, const string &address, C *that, T (C::*getter)()) {
+inline void ofxPublishOscIf(bool (*condition)(), const std::string &ip, int port, const std::string &address, C *that, T (C::*getter)()) {
     ofxGetOscPublisher(ip, port).publishIf(condition, address, *that, getter);
 }
 
 template <typename T, typename C>
-inline void ofxPublishOscIf(bool (*condition)(), const string &ip, int port, const string &address, const C * const that, T (C::*getter)() const) {
+inline void ofxPublishOscIf(bool (*condition)(), const std::string &ip, int port, const std::string &address, const C * const that, T (C::*getter)() const) {
     ofxGetOscPublisher(ip, port).publishIf(condition, address, *that, getter);
 }
 
 template <typename T, typename C>
-inline void ofxPublishOscIf(bool (*condition)(), const string &ip, int port, const string &address, C &that, T (C::*getter)()) {
+inline void ofxPublishOscIf(bool (*condition)(), const std::string &ip, int port, const std::string &address, C &that, T (C::*getter)()) {
     ofxGetOscPublisher(ip, port).publishIf(condition, address, that, getter);
 }
 
 template <typename T, typename C>
-inline void ofxPublishOscIf(bool (*condition)(), const string &ip, int port, const string &address, const C &that, T (C::*getter)() const) {
+inline void ofxPublishOscIf(bool (*condition)(), const std::string &ip, int port, const std::string &address, const C &that, T (C::*getter)() const) {
     ofxGetOscPublisher(ip, port).publishIf(condition, address, that, getter);
 }
 
 #pragma mark condition is method
 
 template <typename T, typename Condition>
-inline void ofxPublishOscIf(Condition *condition, bool (Condition::*method)(), const string &ip, int port, const string &address, T &value) {
+inline void ofxPublishOscIf(Condition *condition, bool (Condition::*method)(), const std::string &ip, int port, const std::string &address, T &value) {
     ofxGetOscPublisher(ip, port).publishIf(*condition, method, address, value);
 }
 
 template <typename T, typename Condition>
-inline void ofxPublishOscIf(Condition &condition, bool (Condition::*method)(), const string &ip, int port, const string &address, T &value) {
+inline void ofxPublishOscIf(Condition &condition, bool (Condition::*method)(), const std::string &ip, int port, const std::string &address, T &value) {
     ofxGetOscPublisher(ip, port).publishIf(condition, method, address, value);
 }
 
 template <typename T, typename Condition>
-inline void ofxPublishOscIf(Condition *condition, bool (Condition::*method)(), const string &ip, int port, const string &address, T (*getter)()) {
+inline void ofxPublishOscIf(Condition *condition, bool (Condition::*method)(), const std::string &ip, int port, const std::string &address, T (*getter)()) {
     ofxGetOscPublisher(ip, port).publishIf(*condition, method, address, getter);
 }
 
 template <typename T, typename Condition>
-inline void ofxPublishOscIf(Condition &condition, bool (Condition::*method)(), const string &ip, int port, const string &address, T (*getter)()) {
+inline void ofxPublishOscIf(Condition &condition, bool (Condition::*method)(), const std::string &ip, int port, const std::string &address, T (*getter)()) {
     ofxGetOscPublisher(ip, port).publishIf(condition, method, address, getter);
 }
 
 template <typename T, typename C, typename Condition>
-inline void ofxPublishOscIf(Condition *condition, bool (Condition::*method)(), const string &ip, int port, const string &address, C *that, T (C::*getter)()) {
+inline void ofxPublishOscIf(Condition *condition, bool (Condition::*method)(), const std::string &ip, int port, const std::string &address, C *that, T (C::*getter)()) {
     ofxGetOscPublisher(ip, port).publishIf(*condition, method, address, *that, getter);
 }
 
 template <typename T, typename C, typename Condition>
-inline void ofxPublishOscIf(Condition *condition, bool (Condition::*method)(), const string &ip, int port, const string &address, const C * const that, T (C::*getter)() const) {
+inline void ofxPublishOscIf(Condition *condition, bool (Condition::*method)(), const std::string &ip, int port, const std::string &address, const C * const that, T (C::*getter)() const) {
     ofxGetOscPublisher(ip, port).publishIf(*condition, method, address, *that, getter);
 }
 
 template <typename T, typename C, typename Condition>
-inline void ofxPublishOscIf(Condition &condition, bool (Condition::*method)(), const string &ip, int port, const string &address, C *that, T (C::*getter)()) {
+inline void ofxPublishOscIf(Condition &condition, bool (Condition::*method)(), const std::string &ip, int port, const std::string &address, C *that, T (C::*getter)()) {
     ofxGetOscPublisher(ip, port).publishIf(condition, method, address, *that, getter);
 }
 
 template <typename T, typename C, typename Condition>
-inline void ofxPublishOscIf(Condition &condition, bool (Condition::*method)(), const string &ip, int port, const string &address, const C * const that, T (C::*getter)() const) {
+inline void ofxPublishOscIf(Condition &condition, bool (Condition::*method)(), const std::string &ip, int port, const std::string &address, const C * const that, T (C::*getter)() const) {
     ofxGetOscPublisher(ip, port).publishIf(condition, method, address, *that, getter);
 }
 
 template <typename T, typename C, typename Condition>
-inline void ofxPublishOscIf(Condition *condition, bool (Condition::*method)(), const string &ip, int port, const string &address, C &that, T (C::*getter)()) {
+inline void ofxPublishOscIf(Condition *condition, bool (Condition::*method)(), const std::string &ip, int port, const std::string &address, C &that, T (C::*getter)()) {
     ofxGetOscPublisher(ip, port).publishIf(*condition, method, address, that, getter);
 }
 
 template <typename T, typename C, typename Condition>
-inline void ofxPublishOscIf(Condition *condition, bool (Condition::*method)(), const string &ip, int port, const string &address, const C &that, T (C::*getter)() const) {
+inline void ofxPublishOscIf(Condition *condition, bool (Condition::*method)(), const std::string &ip, int port, const std::string &address, const C &that, T (C::*getter)() const) {
     ofxGetOscPublisher(ip, port).publishIf(*condition, method, address, that, getter);
 }
 
 template <typename T, typename C, typename Condition>
-inline void ofxPublishOscIf(Condition &condition, bool (Condition::*method)(), const string &ip, int port, const string &address, C &that, T (C::*getter)()) {
+inline void ofxPublishOscIf(Condition &condition, bool (Condition::*method)(), const std::string &ip, int port, const std::string &address, C &that, T (C::*getter)()) {
     ofxGetOscPublisher(ip, port).publishIf(condition, method, address, that, getter);
 }
 
 template <typename T, typename C, typename Condition>
-inline void ofxPublishOscIf(Condition &condition, bool (Condition::*method)(), const string &ip, int port, const string &address, const C &that, T (C::*getter)() const) {
+inline void ofxPublishOscIf(Condition &condition, bool (Condition::*method)(), const std::string &ip, int port, const std::string &address, const C &that, T (C::*getter)() const) {
     ofxGetOscPublisher(ip, port).publishIf(condition, method, address, that, getter);
 }
 
 #pragma mark condition is const method
 
 template <typename T, typename Condition>
-inline void ofxPublishOscIf(const Condition * const condition, bool (Condition::*method)() const, const string &ip, int port, const string &address, T &value) {
+inline void ofxPublishOscIf(const Condition * const condition, bool (Condition::*method)() const, const std::string &ip, int port, const std::string &address, T &value) {
     ofxGetOscPublisher(ip, port).publishIf(*condition, method, address, value);
 }
 
 template <typename T, typename Condition>
-inline void ofxPublishOscIf(const Condition &condition, bool (Condition::*method)() const, const string &ip, int port, const string &address, T &value) {
+inline void ofxPublishOscIf(const Condition &condition, bool (Condition::*method)() const, const std::string &ip, int port, const std::string &address, T &value) {
     ofxGetOscPublisher(ip, port).publishIf(condition, method, address, value);
 }
 
 template <typename T, typename Condition>
-inline void ofxPublishOscIf(const Condition * const condition, bool (Condition::*method)() const, const string &ip, int port, const string &address, T (*getter)()) {
+inline void ofxPublishOscIf(const Condition * const condition, bool (Condition::*method)() const, const std::string &ip, int port, const std::string &address, T (*getter)()) {
     ofxGetOscPublisher(ip, port).publishIf(*condition, method, address, getter);
 }
 
 template <typename T, typename Condition>
-inline void ofxPublishOscIf(const Condition &condition, bool (Condition::*method)() const, const string &ip, int port, const string &address, T (*getter)()) {
+inline void ofxPublishOscIf(const Condition &condition, bool (Condition::*method)() const, const std::string &ip, int port, const std::string &address, T (*getter)()) {
     ofxGetOscPublisher(ip, port).publishIf(condition, method, address, getter);
 }
 
 template <typename T, typename C, typename Condition>
-inline void ofxPublishOscIf(const Condition * const condition, bool (Condition::*method)() const, const string &ip, int port, const string &address, C *that, T (C::*getter)()) {
+inline void ofxPublishOscIf(const Condition * const condition, bool (Condition::*method)() const, const std::string &ip, int port, const std::string &address, C *that, T (C::*getter)()) {
     ofxGetOscPublisher(ip, port).publishIf(*condition, method, address, *that, getter);
 }
 
 template <typename T, typename C, typename Condition>
-inline void ofxPublishOscIf(const Condition * const condition, bool (Condition::*method)() const, const string &ip, int port, const string &address, const C * const that, T (C::*getter)() const) {
+inline void ofxPublishOscIf(const Condition * const condition, bool (Condition::*method)() const, const std::string &ip, int port, const std::string &address, const C * const that, T (C::*getter)() const) {
     ofxGetOscPublisher(ip, port).publishIf(*condition, method, address, *that, getter);
 }
 
 template <typename T, typename C, typename Condition>
-inline void ofxPublishOscIf(const Condition &condition, bool (Condition::*method)() const, const string &ip, int port, const string &address, C *that, T (C::*getter)()) {
+inline void ofxPublishOscIf(const Condition &condition, bool (Condition::*method)() const, const std::string &ip, int port, const std::string &address, C *that, T (C::*getter)()) {
     ofxGetOscPublisher(ip, port).publishIf(condition, method, address, *that, getter);
 }
 
 template <typename T, typename C, typename Condition>
-inline void ofxPublishOscIf(const Condition &condition, bool (Condition::*method)() const, const string &ip, int port, const string &address, const C * const that, T (C::*getter)() const) {
+inline void ofxPublishOscIf(const Condition &condition, bool (Condition::*method)() const, const std::string &ip, int port, const std::string &address, const C * const that, T (C::*getter)() const) {
     ofxGetOscPublisher(ip, port).publishIf(condition, method, address, *that, getter);
 }
 
 template <typename T, typename C, typename Condition>
-inline void ofxPublishOscIf(const Condition * const condition, bool (Condition::*method)() const, const string &ip, int port, const string &address, C &that, T (C::*getter)()) {
+inline void ofxPublishOscIf(const Condition * const condition, bool (Condition::*method)() const, const std::string &ip, int port, const std::string &address, C &that, T (C::*getter)()) {
     ofxGetOscPublisher(ip, port).publishIf(*condition, method, address, that, getter);
 }
 
 template <typename T, typename C, typename Condition>
-inline void ofxPublishOscIf(const Condition * const condition, bool (Condition::*method)() const, const string &ip, int port, const string &address, const C &that, T (C::*getter)() const) {
+inline void ofxPublishOscIf(const Condition * const condition, bool (Condition::*method)() const, const std::string &ip, int port, const std::string &address, const C &that, T (C::*getter)() const) {
     ofxGetOscPublisher(ip, port).publishIf(*condition, method, address, that, getter);
 }
 
 template <typename T, typename C, typename Condition>
-inline void ofxPublishOscIf(const Condition &condition, bool (Condition::*method)() const, const string &ip, int port, const string &address, C &that, T (C::*getter)()) {
+inline void ofxPublishOscIf(const Condition &condition, bool (Condition::*method)() const, const std::string &ip, int port, const std::string &address, C &that, T (C::*getter)()) {
     ofxGetOscPublisher(ip, port).publishIf(condition, method, address, that, getter);
 }
 
 template <typename T, typename C, typename Condition>
-inline void ofxPublishOscIf(const Condition &condition, bool (Condition::*method)() const, const string &ip, int port, const string &address, const C &that, T (C::*getter)() const) {
+inline void ofxPublishOscIf(const Condition &condition, bool (Condition::*method)() const, const std::string &ip, int port, const std::string &address, const C &that, T (C::*getter)() const) {
     ofxGetOscPublisher(ip, port).publishIf(condition, method, address, that, getter);
 }
 
@@ -1059,11 +1059,11 @@ inline void ofxPublishOscIf(const Condition &condition, bool (Condition::*method
 /// \name ofxUnpublishOsc
 /// \{
 
-inline void ofxUnpublishOsc(const string &ip, int port, const string &address) {
+inline void ofxUnpublishOsc(const std::string &ip, int port, const std::string &address) {
     ofxGetOscPublisher(ip, port).unpublish(address);
 }
 
-inline void ofxUnpublishOsc(const string &ip, int port) {
+inline void ofxUnpublishOsc(const std::string &ip, int port) {
     ofxGetOscPublisher(ip, port).unpublish();
 }
 
@@ -1072,48 +1072,48 @@ inline void ofxUnpublishOsc(const string &ip, int port) {
 #pragma mark register
 
 template <typename T>
-inline void ofxRegisterPublishingOsc(const string &ip, int port, const string &address, T &value) {
+inline void ofxRegisterPublishingOsc(const std::string &ip, int port, const std::string &address, T &value) {
     ofxGetOscPublisher(ip, port).doRegister(address, value);
 }
 
 template <typename T>
-inline void ofxRegisterPublishingOsc(const string &ip, int port, const string &address, T (*getter)()) {
+inline void ofxRegisterPublishingOsc(const std::string &ip, int port, const std::string &address, T (*getter)()) {
     ofxGetOscPublisher(ip, port).doRegister(address, getter);
 }
 
 template <typename T, typename C>
-inline void ofxRegisterPublishingOsc(const string &ip, int port, const string &address, C *that, T (C::*getter)()) {
+inline void ofxRegisterPublishingOsc(const std::string &ip, int port, const std::string &address, C *that, T (C::*getter)()) {
     ofxGetOscPublisher(ip, port).doRegister(address, *that, getter);
 }
 
 template <typename T, typename C>
-inline void ofxRegisterPublishingOsc(const string &ip, int port, const string &address, const C * const that, T (C::*getter)() const) {
+inline void ofxRegisterPublishingOsc(const std::string &ip, int port, const std::string &address, const C * const that, T (C::*getter)() const) {
     ofxGetOscPublisher(ip, port).doRegister(address, *that, getter);
 }
 
 template <typename T, typename C>
-inline void ofxRegisterPublishingOsc(const string &ip, int port, const string &address, C &that, T (C::*getter)()) {
+inline void ofxRegisterPublishingOsc(const std::string &ip, int port, const std::string &address, C &that, T (C::*getter)()) {
     ofxGetOscPublisher(ip, port).doRegister(address, that, getter);
 }
 
 template <typename T, typename C>
-inline void ofxRegisterPublishingOsc(const string &ip, int port, const string &address, const C &that, T (C::*getter)() const) {
+inline void ofxRegisterPublishingOsc(const std::string &ip, int port, const std::string &address, const C &that, T (C::*getter)() const) {
     ofxGetOscPublisher(ip, port).doRegister(address, that, getter);
 }
 
 #pragma mark publish registered
 
-inline void ofxPublishRegisteredOsc(const string &ip, int port, const string &address) {
+inline void ofxPublishRegisteredOsc(const std::string &ip, int port, const std::string &address) {
     ofxGetOscPublisher(ip, port).publishRegistered(address);
 }
 
 #pragma mark unregister
 
-inline void ofxUnregisterPublishingOsc(const string &ip, int port, const string &address) {
+inline void ofxUnregisterPublishingOsc(const std::string &ip, int port, const std::string &address) {
     ofxGetOscPublisher(ip, port).unregister(address);
 }
 
-inline void ofxUnregisterPublishingOsc(const string &ip, int port) {
+inline void ofxUnregisterPublishingOsc(const std::string &ip, int port) {
     ofxGetOscPublisher(ip, port).unregister();
 }
 

--- a/src/ofxOscPublisher.h
+++ b/src/ofxOscPublisher.h
@@ -1191,16 +1191,17 @@ inline ofxOscPublisherIdentifier ofxPublishOscIf(ConditionObjectPtrOrRef &condit
 /// \name ofxUnpublishOsc
 /// \{
 
+inline void ofxUnpublishOsc(const ofxOscPublisherIdentifier &identifier) {
+    if(!identifier.isValid()) return;
+    ofxGetOscPublisher(identifier.getKey().ip, identifier.getKey().port).unpublish(identifier);
+}
+
 inline void ofxUnpublishOsc(const std::string &ip, int port, const std::string &address) {
     ofxGetOscPublisher(ip, port).unpublish(address);
 }
 
 inline void ofxUnpublishOsc(const std::string &ip, int port) {
     ofxGetOscPublisher(ip, port).unpublish();
-}
-
-inline void ofxUnpublishOsc(const ofxOscPublisherIdentifier &identifier) {
-    ofxGetOscPublisher(identifier.key.ip, identifier.key.port).unpublish(identifier);
 }
 
 inline void ofxUnpublishOsc() {
@@ -1270,6 +1271,11 @@ inline void ofxPublishRegisteredOsc(const ofxOscPublisherIdentifier &identifier)
 
 /// \name ofxUnregisterPublishingOsc
 /// \{
+
+inline void ofxUnregisterPublishingOsc(const ofxOscPublisherIdentifier &identifier) {
+    if(!identifier.isValid()) return;
+    ofxGetOscPublisher(identifier.getKey().ip, identifier.getKey().port).unregister(identifier);
+}
 
 inline void ofxUnregisterPublishingOsc(const std::string &ip, int port, const std::string &address) {
     ofxGetOscPublisher(ip, port).unregister(address);

--- a/src/ofxOscPublisher.h
+++ b/src/ofxOscPublisher.h
@@ -527,7 +527,7 @@ namespace ofx {
             ParameterRef ref;
             Destination key;
             
-            void invalidation() {
+            void invalidate() {
                 address = "";
                 ref = nullptr;
                 key = Destination();
@@ -548,6 +548,7 @@ namespace ofx {
     public:
         class OscPublisher {
             Targets::const_iterator findFromTargets(const Identifier &identifier, const Targets &targets) const {
+                if(!identifier.isValid()) return targets.end();
                 Targets::const_iterator it = targets.find(identifier.address);
                 if(it != targets.end()) {
                     for(std::size_t i = 0, size = targets.count(identifier.address); i < size; ++i, ++it) {
@@ -822,11 +823,13 @@ namespace ofx {
                 if(targets.find(address) == targets.end()) targets.erase(address);
             }
             
-            void unpublish(const Identifier &identifier) {
+            void unpublish(Identifier &identifier) {
+                if(!identifier.isValid()) return;
                 Targets::const_iterator it{findPublished(identifier)};
                 if(it != targets.end()) {
                     targets.erase(it);
                 }
+                identifier.invalidate();
             }
             
             void unpublish() {
@@ -845,6 +848,7 @@ namespace ofx {
             }
             
             void stopPublishTemporary(const Identifier &identifier) {
+                if(!identifier.isValid()) return;
                 Targets::const_iterator it{findPublished(identifier)};
                 if(it != targets.end()) {
                     it->second->setEnablePublish(false);
@@ -861,6 +865,7 @@ namespace ofx {
             }
             
             void resumePublishTemporary(const Identifier &identifier) {
+                if(!identifier.isValid()) return;
                 Targets::const_iterator it{findPublished(identifier)};
                 if(it != targets.end()) {
                     it->second->setEnablePublish(true);
@@ -919,7 +924,7 @@ namespace ofx {
             }
             
             inline void publishRegistered(const Identifier &identifier) {
-                // TODO: implement
+                if(!identifier.isValid()) return;
                 Targets::const_iterator it{findRegistered(identifier)};
                 if(it != registeredTargets.end()) {
                     ofxOscMessage m;
@@ -934,12 +939,13 @@ namespace ofx {
                 if(registeredTargets.find(address) == registeredTargets.end()) registeredTargets.erase(address);
             }
             
-            inline void unregister(const Identifier &identifier) {
-                // TODO: implement
+            inline void unregister(Identifier &identifier) {
+                if(!identifier.isValid()) return;
                 Targets::const_iterator it{findRegistered(identifier)};
                 if(it != registeredTargets.end()) {
                     registeredTargets.erase(it);
                 }
+                identifier.invalidate();
             }
             
             inline void unregister() {
@@ -953,6 +959,7 @@ namespace ofx {
             }
             
             inline bool isPublished(const Identifier &identifier) const {
+                if(!identifier.isValid()) false;
                 return isPublished() && (findPublished(identifier) != targets.end());
             }
             
@@ -966,6 +973,7 @@ namespace ofx {
             }
             
             inline bool isEnabled(const Identifier &identifier) const {
+                if(!identifier.isValid()) return false;
                 Targets::const_iterator it{findPublished(identifier)};
                 return (it != targets.end()) && it->second->isPublishNow();
             }
@@ -1290,7 +1298,7 @@ inline ofxOscPublisherIdentifier ofxPublishOscIf(ConditionObjectPtrOrRef &condit
 /// \name ofxUnpublishOsc
 /// \{
 
-inline void ofxUnpublishOsc(const ofxOscPublisherIdentifier &identifier) {
+inline void ofxUnpublishOsc(ofxOscPublisherIdentifier &identifier) {
     if(!identifier.isValid()) return;
     ofxGetOscPublisher(identifier.getKey().ip, identifier.getKey().port).unpublish(identifier);
 }
@@ -1361,7 +1369,8 @@ inline void ofxPublishRegisteredOsc(const std::string &ip, int port, const std::
 }
 
 inline void ofxPublishRegisteredOsc(const ofxOscPublisherIdentifier &identifier) {
-//    ofxGetOscPublisher(identifier.key.ip, identifier.key.port).publishRegistered();
+    if(!identifier.isValid()) return;
+    ofxGetOscPublisher(identifier.getKey().ip, identifier.getKey().port).publishRegistered(identifier);
 }
 
 /// \}
@@ -1371,7 +1380,7 @@ inline void ofxPublishRegisteredOsc(const ofxOscPublisherIdentifier &identifier)
 /// \name ofxUnregisterPublishingOsc
 /// \{
 
-inline void ofxUnregisterPublishingOsc(const ofxOscPublisherIdentifier &identifier) {
+inline void ofxUnregisterPublishingOsc(ofxOscPublisherIdentifier &identifier) {
     if(!identifier.isValid()) return;
     ofxGetOscPublisher(identifier.getKey().ip, identifier.getKey().port).unregister(identifier);
 }

--- a/src/ofxOscPublisher.h
+++ b/src/ofxOscPublisher.h
@@ -45,12 +45,26 @@ namespace ofx {
 #undef define_is_integral
         
 #define type_ref(T) typename add_reference_if_non_arithmetic<T>::type
-
-        template <bool b>
-        struct enable;
         
-        template <>
-        struct enable<true> { typedef void type; };
+        namespace impl {
+            template <bool b, typename T>
+            struct enable {};
+            
+            template <typename T>
+            struct enable<true, T> { typedef T type;};
+        }
+        template <bool b, typename T = void>
+        struct enable : impl::enable<b, T> {};
+        
+        template <typename T>
+        struct is_pointer {
+            static const bool value = false;
+        };
+        
+        template <typename T>
+        struct is_pointer<T *> {
+            static const bool value = true;
+        };
         
         template <typename T>
         struct is_integral_and_lt_64bit {
@@ -1131,7 +1145,7 @@ inline ofxOscPublisherIdentifier ofxPublishOsc(const std::string &ip, int port, 
 }
 
 // TODO: add document
-template <typename T, typename U = typename std::enable_if<!std::is_pointer<T>::value>::type>
+template <typename T, typename U = typename ofx::enable<!ofx::is_pointer<T>::value>::type>
 inline ofxOscPublisherIdentifier ofxPublishOsc(const std::string &ip, int port, const std::string &address, const T &value, bool whenValueIsChanged = true) {
     return ofxGetOscPublisher(ip, port).publish(address, value, whenValueIsChanged);
 }

--- a/src/ofxOscPublisher.h
+++ b/src/ofxOscPublisher.h
@@ -591,6 +591,11 @@ namespace ofx {
                 return {address, ref, destination};
             }
             
+            Identifier publish(const std::string &address, const char * const value, bool whenValueIsChanged = true) {
+                ParameterRef p;
+                return publish(address, std::string(value), whenValueIsChanged);
+            }
+            
             template <typename T>
             Identifier publish(const std::string &address, T &value, bool whenValueIsChanged = true) {
                 ParameterRef p;
@@ -649,6 +654,11 @@ namespace ofx {
 
 #pragma mark publish conditional
 #pragma mark condition is bool value ref
+            
+            Identifier publishIf(bool &condition, const std::string &address,const char * const value) {
+                ParameterRef p;
+                return publishIf(condition, address, std::string(value));
+            }
             
             template <typename T>
             Identifier publishIf(bool &condition, const std::string &address, T &value) {

--- a/src/ofxOscSubscriber.h
+++ b/src/ofxOscSubscriber.h
@@ -304,7 +304,7 @@ namespace ofx {
         struct LambdaCallbackParameter : AbstractParameter, SetImplementation {
         public:
             typedef std::function<void(ofxOscMessage &)> Callback;
-            LambdaCallbackParameter(Callback &callback)
+            LambdaCallbackParameter(const Callback &callback)
             : callback(callback) {}
             
             virtual void read(ofxOscMessage &message) { callback(message); }
@@ -364,7 +364,7 @@ namespace ofx {
             }
             
 #if ENABLE_FUNCTIONAL
-            inline void subscribe(const std::string &address, std::function<void(ofxOscMessage &)> callback) {
+            inline void subscribe(const std::string &address, const std::function<void(ofxOscMessage &)> callback) {
                 subscribe(address, ParameterRef(new LambdaCallbackParameter(callback)));
             }
 #endif
@@ -395,7 +395,7 @@ namespace ofx {
             }
             
 #if ENABLE_FUNCTIONAL
-            inline void setLeakPicker(std::function<void(ofxOscMessage &)> &callback) {
+            inline void setLeakPicker(const std::function<void(ofxOscMessage &)> &callback) {
                 setLeakPicker(ParameterRef(new LambdaCallbackParameter(callback)));
             }
 #endif
@@ -809,7 +809,7 @@ inline void ofxSetLeakedOscPicker(int port, const C *that, R (C::*callback)(ofxO
 }
 
 #if ENABLE_FUNCTIONAL
-inline void ofxSetLeakedOscPicker(int port, std::function<void(ofxOscMessage &)> &callback) {
+inline void ofxSetLeakedOscPicker(int port, const std::function<void(ofxOscMessage &)> &callback) {
     ofxGetOscSubscriber(port).setLeakPicker(callback);
 }
 #endif

--- a/src/ofxOscSubscriber.h
+++ b/src/ofxOscSubscriber.h
@@ -21,7 +21,7 @@ namespace ofx {
         struct SetImplementation {
         protected:
 #define define_set_arithmetic(type) \
-            inline void set(ofxOscMessage &m, type &v, size_t offset = 0) { \
+            inline void set(ofxOscMessage &m, type &v, std::size_t offset = 0) { \
                 if(m.getArgType(offset) == OFXOSC_TYPE_INT32) v = m.getArgAsInt32(offset); \
                 else if(m.getArgType(offset) == OFXOSC_TYPE_INT64) v = m.getArgAsInt64(offset); \
                 else if(m.getArgType(offset) == OFXOSC_TYPE_FLOAT) v = m.getArgAsFloat(offset); \
@@ -43,22 +43,22 @@ namespace ofx {
             define_set_arithmetic(double);
 #undef define_set_arithmetic
             
-            inline void set(ofxOscMessage &m, std::string &v, size_t offset = 0) {
+            inline void set(ofxOscMessage &m, std::string &v, std::size_t offset = 0) {
                 v = m.getArgAsString(offset);
             }
             
 #if ENABLE_OF_BUFFER
-            inline void set(ofxOscMessage &m, ofBuffer &v, size_t offset = 0) {
+            inline void set(ofxOscMessage &m, ofBuffer &v, std::size_t offset = 0) {
                 v = m.getArgAsBlob(offset);
             }
 #endif
             
-            inline void set(ofxOscMessage &m, ofColor &v, size_t offset = 0)      { setColor<unsigned char>(m, v, 255, offset); }
-            inline void set(ofxOscMessage &m, ofShortColor &v, size_t offset = 0) { setColor<unsigned short>(m, v, 65535, offset); }
-            inline void set(ofxOscMessage &m, ofFloatColor &v, size_t offset = 0) { setColor<float>(m, v, 1.0f, offset); }
+            inline void set(ofxOscMessage &m, ofColor &v, std::size_t offset = 0)      { setColor<unsigned char>(m, v, 255, offset); }
+            inline void set(ofxOscMessage &m, ofShortColor &v, std::size_t offset = 0) { setColor<unsigned short>(m, v, 65535, offset); }
+            inline void set(ofxOscMessage &m, ofFloatColor &v, std::size_t offset = 0) { setColor<float>(m, v, 1.0f, offset); }
             
             template <typename U>
-            inline void setColor(ofxOscMessage &m, ofColor_<U> &v, U defaultValue, size_t offset = 0) {
+            inline void setColor(ofxOscMessage &m, ofColor_<U> &v, U defaultValue, std::size_t offset = 0) {
                 if(m.getNumArgs() == 1) {
                     set(m, v.r, offset);
                     set(m, v.g, offset);
@@ -77,42 +77,42 @@ namespace ofx {
                 }
             }
             
-            inline void set(ofxOscMessage &m, ofVec2f &v, size_t offset = 0)      { setVec<2>(m, v, offset); }
-            inline void set(ofxOscMessage &m, ofVec3f &v, size_t offset = 0)      { setVec<3>(m, v, offset); }
-            inline void set(ofxOscMessage &m, ofVec4f &v, size_t offset = 0)      { setVec<4>(m, v, offset); }
-            inline void set(ofxOscMessage &m, ofQuaternion &v, size_t offset = 0) { setVec<4>(m, v, offset); }
-            inline void set(ofxOscMessage &m, ofMatrix3x3 &v, size_t offset = 0)  { setVec<9>(m, v, offset); }
+            inline void set(ofxOscMessage &m, ofVec2f &v, std::size_t offset = 0)      { setVec<2>(m, v, offset); }
+            inline void set(ofxOscMessage &m, ofVec3f &v, std::size_t offset = 0)      { setVec<3>(m, v, offset); }
+            inline void set(ofxOscMessage &m, ofVec4f &v, std::size_t offset = 0)      { setVec<4>(m, v, offset); }
+            inline void set(ofxOscMessage &m, ofQuaternion &v, std::size_t offset = 0) { setVec<4>(m, v, offset); }
+            inline void set(ofxOscMessage &m, ofMatrix3x3 &v, std::size_t offset = 0)  { setVec<9>(m, v, offset); }
             
-            template <size_t n, typename U>
-            inline void setVec(ofxOscMessage &m, U &v, size_t offset = 0) {
-                for(int i = 0; i < min(static_cast<size_t>(m.getNumArgs() - offset), n); i++) {
+            template <std::size_t n, typename U>
+            inline void setVec(ofxOscMessage &m, U &v, std::size_t offset = 0) {
+                for(int i = 0; i < min(static_cast<std::size_t>(m.getNumArgs() - offset), n); i++) {
                     set(m, v[i], offset + i);
                 }
             }
             
-            inline void set(ofxOscMessage &m, ofMatrix4x4 &v, size_t offset = 0) {
+            inline void set(ofxOscMessage &m, ofMatrix4x4 &v, std::size_t offset = 0) {
                 for(int j = 0; j < 4; j++) for(int i = 0; i < 4; i++) {
                     set(m, v(i, j), offset + 4 * j + i);
                 }
             }
             
-            inline void set(ofxOscMessage &m, ofRectangle &v, size_t offset = 0) {
+            inline void set(ofxOscMessage &m, ofRectangle &v, std::size_t offset = 0) {
                 set(m, v.x,      offset + 0);
                 set(m, v.y,      offset + 1);
                 set(m, v.width,  offset + 2);
                 set(m, v.height, offset + 3);
             }
             
-            template <typename U, size_t size>
-            inline void set(ofxOscMessage &m, U (&v)[size], size_t offset = 0) {
+            template <typename U, std::size_t size>
+            inline void set(ofxOscMessage &m, U (&v)[size], std::size_t offset = 0) {
                 for(int i = 0; i < min(size, (m.getNumArgs() - offset) / ofxpubsubosc::type_traits<U>::size); i++) {
                     set(m, v[i], offset + i * ofxpubsubosc::type_traits<U>::size);
                 }
             }
             
             template <typename U>
-            inline void set(ofxOscMessage &m, vector<U> &v, size_t offset = 0) {
-                size_t num = (m.getNumArgs() - offset) / ofxpubsubosc::type_traits<U>::size;
+            inline void set(ofxOscMessage &m, vector<U> &v, std::size_t offset = 0) {
+                std::size_t num = (m.getNumArgs() - offset) / ofxpubsubosc::type_traits<U>::size;
                 if(v.size() != num) v.resize(num);
                 for(int i = 0; i < num; i++) {
                     set(m, v[i], offset + i * ofxpubsubosc::type_traits<U>::size);
@@ -122,13 +122,13 @@ namespace ofx {
 #pragma mark ofParameter<T> / ofParameterGroup
             
             template <typename U>
-            inline void set(ofxOscMessage &m, ofParameter<U> &p, size_t offset = 0) {
+            inline void set(ofxOscMessage &m, ofParameter<U> &p, std::size_t offset = 0) {
                 U u;
                 set(m, u, offset);
                 p.set(u);
             }
 
-            inline void set(ofxOscMessage &m, ofAbstractParameter &p, size_t offset = 0) {
+            inline void set(ofxOscMessage &m, ofAbstractParameter &p, std::size_t offset = 0) {
 #define type_convert(type_) if(p.type() == typeid(ofParameter<type_>).name()) { set(m, p.cast<type_>(), offset); return; }
                 type_convert(float);
                 type_convert(double);
@@ -163,7 +163,7 @@ namespace ofx {
 #undef type_convert
             }
             
-            inline void set(ofxOscMessage &m, ofParameterGroup &pg, size_t offset = 0) {
+            inline void set(ofxOscMessage &m, ofParameterGroup &pg, std::size_t offset = 0) {
                 if(m.getArgType(0) == OFXOSC_TYPE_INT32) {
                     if(pg.size() <= m.getArgAsInt32(0)) {
                         ofLogWarning("ofxOscSubscriber") << "ofAbstractParameterGroup: not contain index \"" << m.getArgAsInt32(0) << "\"";

--- a/src/ofxOscSubscriber.h
+++ b/src/ofxOscSubscriber.h
@@ -31,6 +31,7 @@ namespace ofx {
                 else if(m.getArgType(offset) == OFXOSC_TYPE_INT64) v = m.getArgAsInt64(offset); \
                 else if(m.getArgType(offset) == OFXOSC_TYPE_FLOAT) v = m.getArgAsFloat(offset); \
                 else if(m.getArgType(offset) == OFXOSC_TYPE_DOUBLE) v = m.getArgAsDouble(offset); \
+                else if(m.getArgType(offset) == OFXOSC_TYPE_STRING) v = ofToDouble(m.getArgAsString(offset)); \
             }
 #else
 #define define_set_arithmetic(type) \
@@ -38,8 +39,10 @@ namespace ofx {
                 if(m.getArgType(offset) == OFXOSC_TYPE_INT32) v = m.getArgAsInt32(offset); \
                 else if(m.getArgType(offset) == OFXOSC_TYPE_INT64) v = m.getArgAsInt64(offset); \
                 else if(m.getArgType(offset) == OFXOSC_TYPE_FLOAT) v = m.getArgAsFloat(offset); \
+                else if(m.getArgType(offset) == OFXOSC_TYPE_STRING) v = ofToDouble(m.getArgAsString(offset)); \
             }
 #endif
+            
             define_set_arithmetic(bool);
             define_set_arithmetic(char);
             define_set_arithmetic(unsigned char);
@@ -57,7 +60,16 @@ namespace ofx {
 #undef define_set_arithmetic
             
             inline void set(ofxOscMessage &m, std::string &v, std::size_t offset = 0) {
-                v = m.getArgAsString(offset);
+                if(m.getArgType(offset) == OFXOSC_TYPE_STRING) v = m.getArgAsString(offset);
+                else if(m.getArgType(offset) == OFXOSC_TYPE_FLOAT) v = ofToString(m.getArgAsFloat(offset));
+#if ENABLE_FUNCTIONAL
+                else if(m.getArgType(offset) == OFXOSC_TYPE_DOUBLE) v = ofToString(m.getArgAsDouble(offset));
+                else if(m.getArgType(offset) == OFXOSC_TYPE_INT32) v = ofToString(m.getArgAsInt32(offset));
+                else if(m.getArgType(offset) == OFXOSC_TYPE_INT64) v = ofToString(m.getArgAsInt64(offset));
+#else
+                else if(m.getArgType(offset) == OFXOSC_TYPE_INT) v = ofToString(m.getArgAsInt(offset));
+#endif
+                else v = m.getArgAsString(offset);
             }
             
 #if ENABLE_OF_BUFFER

--- a/src/ofxOscSubscriber.h
+++ b/src/ofxOscSubscriber.h
@@ -522,40 +522,16 @@ namespace ofx {
         
         const_iterator begin() const { return managers.begin(); }
         const_iterator end() const { return managers.end(); }
-        const_iterator cbegin() const {
-#if ENABLE_CPP11
-            return managers.begin();
-#else
-            return managers.cbegin();
-#endif
-        }
-        const_iterator cend() const {
-#if ENABLE_CPP11
-            return managers.end();
-#else
-            return managers.cend();
-#endif
-        }
+        const_iterator cbegin() const { return managers.begin(); }
+        const_iterator cend() const { return managers.end(); }
         
         reverse_iterator rbegin() { return managers.rbegin(); }
         reverse_iterator rend() { return managers.rend(); }
         
         const_reverse_iterator rbegin() const { return managers.rbegin(); }
         const_reverse_iterator rend() const { return managers.rend(); }
-        const_reverse_iterator crbegin() const {
-#if ENABLE_CPP11
-            return managers.rbegin();
-#else
-            return managers.crbegin();
-#endif
-        }
-        const_reverse_iterator crend() const {
-#if ENABLE_CPP11
-            return managers.rend();
-#else
-            return managers.crend();
-#endif
-        }
+        const_reverse_iterator crbegin() const { return managers.rbegin(); }
+        const_reverse_iterator crend() const { return managers.crend(); }
     };
 };
 

--- a/src/ofxOscSubscriber.h
+++ b/src/ofxOscSubscriber.h
@@ -414,7 +414,7 @@ namespace ofx {
             }
             
             inline bool isSubscribed() const {
-                return targets.empty();
+                return !targets.empty();
             }
             
             inline bool isSubscribed(const std::string &address) const {

--- a/src/ofxOscSubscriber.h
+++ b/src/ofxOscSubscriber.h
@@ -13,6 +13,8 @@
 #include "details/ofxpubsubosc_settings.h"
 #include "details/ofxpubsubosc_type_traits.h"
 
+#include <initializer_list>
+
 namespace ofx {
     using namespace ofxpubsubosc;
     

--- a/src/ofxOscSubscriber.h
+++ b/src/ofxOscSubscriber.h
@@ -22,13 +22,22 @@ namespace ofx {
     private:
         struct SetImplementation {
         protected:
+#if ENABLE_FUNCTIONAL
+#define define_set_arithmetic(type) \
+            inline void set(ofxOscMessage &m, type &v, std::size_t offset = 0) { \
+                if(m.getArgType(offset) == OFXOSC_TYPE_INT32) v = m.getArgAsInt32(offset); \
+                else if(m.getArgType(offset) == OFXOSC_TYPE_INT64) v = m.getArgAsInt64(offset); \
+                else if(m.getArgType(offset) == OFXOSC_TYPE_FLOAT) v = m.getArgAsFloat(offset); \
+                else if(m.getArgType(offset) == OFXOSC_TYPE_DOUBLE) v = m.getArgAsDouble(offset); \
+            }
+#else
 #define define_set_arithmetic(type) \
             inline void set(ofxOscMessage &m, type &v, std::size_t offset = 0) { \
                 if(m.getArgType(offset) == OFXOSC_TYPE_INT32) v = m.getArgAsInt32(offset); \
                 else if(m.getArgType(offset) == OFXOSC_TYPE_INT64) v = m.getArgAsInt64(offset); \
                 else if(m.getArgType(offset) == OFXOSC_TYPE_FLOAT) v = m.getArgAsFloat(offset); \
             }
-            
+#endif
             define_set_arithmetic(bool);
             define_set_arithmetic(char);
             define_set_arithmetic(unsigned char);

--- a/src/ofxOscSubscriber.h
+++ b/src/ofxOscSubscriber.h
@@ -790,4 +790,13 @@ inline void ofxRemoveLeakedOscPicker(int port) {
     ofxGetOscSubscriber(port).removeLeakPicker();
 }
 
+inline void ofxRemoveLeakedOscPicker() {
+    ofxOscSubscriberManager &manager = ofxGetOscSubscriberManager();
+    ofxOscSubscriberManager::iterator it  = manager.begin(),
+                                      end = manager.end();
+    for(; it != end; it++) {
+        it->second->removeLeakPicker();
+    }
+}
+
 /// \}

--- a/src/ofxOscSubscriber.h
+++ b/src/ofxOscSubscriber.h
@@ -45,6 +45,28 @@ namespace ofx {
         template <typename T>
         struct function_info : public function_info_impl<T, is_callable<T>::value> {};
         
+        template <typename U, typename ret, typename ... arguments>
+        struct function_info<ret(U::*)(arguments ...) const> {
+            static constexpr bool is_function = true;
+            static constexpr std::size_t arity = sizeof...(arguments);
+            using result_type = ret;
+            using arguments_types_tuple = std::tuple<arguments ...>;
+            template <std::size_t index>
+            using argument_type = get_type<std::tuple_element<index, arguments_types_tuple>>;
+            using function_type = std::function<result_type(arguments ...)>;
+        };
+        
+        template <typename U, typename ret, typename ... arguments>
+        struct function_info<ret(U::*)(arguments ...)> {
+            static constexpr bool is_function = true;
+            static constexpr std::size_t arity = sizeof...(arguments);
+            using result_type = ret;
+            using arguments_types_tuple = std::tuple<arguments ...>;
+            template <std::size_t index>
+            using argument_type = get_type<std::tuple_element<index, arguments_types_tuple>>;
+            using function_type = std::function<result_type(arguments ...)>;
+        };
+        
         template <typename ret, typename ... arguments>
         struct function_info<ret(*)(arguments ...)> {
             static constexpr bool is_function = true;

--- a/src/ofxOscSubscriber.h
+++ b/src/ofxOscSubscriber.h
@@ -655,6 +655,12 @@ inline void ofxUnsubscribeOsc(int port) {
 
 /// \}
 
+#pragma mark notify messages manually
+
+inline void ofxNotifyToSubscribedOsc(int port, ofxOscMessage &m) {
+    ofxGetOscSubscriber(port).notify(m);
+}
+
 #pragma mark interface about leaked osc
 
 /// \name ofxSetLeakedOscPicker

--- a/src/ofxOscSubscriber.h
+++ b/src/ofxOscSubscriber.h
@@ -1022,4 +1022,4 @@ inline void ofxRemoveLeakedOscPicker() {
 
 /// \}
 
-#define ofxSubScribeOscWithSameName(port, name) ofxSubscribeOsc(port, "/" #name, name)
+#define SubscribeOsc(port, name) ofxSubscribeOsc(port, "/" #name, name)

--- a/src/ofxOscSubscriber.h
+++ b/src/ofxOscSubscriber.h
@@ -931,3 +931,5 @@ inline void ofxRemoveLeakedOscPicker() {
 }
 
 /// \}
+
+#define ofxSubScribeOscWithSameName(port, name) ofxSubscribeOsc(port, "/" #name, name)

--- a/src/ofxOscSubscriber.h
+++ b/src/ofxOscSubscriber.h
@@ -683,6 +683,32 @@ inline void ofxSubscribeOsc(int port, const std::string &address, std::function<
 }
 #endif
 
+#if ENABLE_CPP11
+
+template <typename ... Args>
+inline void ofxSubscribeOsc(const std::initializer_list<int> &ports, const std::string &address, Args & ... args) {
+    for(auto &port : ports) {
+        ofxSubscribeOsc(port, address, args ...);
+    }
+}
+
+template <typename ... Args>
+inline void ofxSubscribeOsc(int port, const std::initializer_list<const std::string> &addresses, Args & ... args) {
+    auto &subscriber = ofxGetOscSubscriber(port);
+    for(auto &address : addresses) {
+        subscriber.subscribe(address, args ...);
+    }
+}
+
+template <typename ... Args>
+inline void ofxSubscribeOsc(const std::initializer_list<int> &ports, const std::initializer_list<const std::string> &addresses, Args & ... args) {
+    for(auto &port : ports) {
+        ofxSubscribeOsc(port, addresses, args ...);
+    }
+}
+
+#endif
+
 /// \}
 
 #pragma mark unsubscribe

--- a/src/ofxOscSubscriber.h
+++ b/src/ofxOscSubscriber.h
@@ -302,7 +302,7 @@ namespace ofx {
         template <typename R>
         struct CallbackParameter : AbstractParameter, SetImplementation {
         public:
-            typedef std::function<R(ofxOscMessage &)> Callback;
+            using Callback = std::function<R(ofxOscMessage &)>;
             CallbackParameter(const Callback &callback)
             : callback(callback) {}
             
@@ -314,7 +314,7 @@ namespace ofx {
         
         template <typename C, typename R>
         struct MethodCallbackParameter : AbstractParameter, SetImplementation {
-            typedef R (C::*Callback)(ofxOscMessage &);
+            using Callback = R (C::*)(ofxOscMessage &);
             MethodCallbackParameter(C &that, Callback callback)
             : that(that), callback(callback) {}
             
@@ -327,7 +327,7 @@ namespace ofx {
 
         template <typename C, typename R>
         struct ConstMethodCallbackParameter : AbstractParameter, SetImplementation {
-            typedef R (C::*Callback)(ofxOscMessage &) const;
+            using Callback = R (C::*)(ofxOscMessage &) const;
             ConstMethodCallbackParameter(const C &that, Callback callback)
             : that(that), callback(callback) {}
             
@@ -338,9 +338,9 @@ namespace ofx {
             const C &that;
         };
         
-        typedef std::shared_ptr<AbstractParameter> ParameterRef;
-        typedef std::shared_ptr<ofxOscReceiver> OscReceiverRef;
-        typedef std::multimap<std::string, ParameterRef> Targets;
+        using ParameterRef = std::shared_ptr<AbstractParameter>;
+        using OscReceiverRef = std::shared_ptr<ofxOscReceiver>;
+        using Targets = std::multimap<std::string, ParameterRef>;
         
         class Identifier {
             std::string address;
@@ -529,7 +529,7 @@ namespace ofx {
                 }
             }
             
-            typedef  std::shared_ptr<OscSubscriber> Ref;
+            using Ref = std::shared_ptr<OscSubscriber>;
         private:
             OscSubscriber(int port)
             : port(port) {
@@ -580,7 +580,7 @@ namespace ofx {
         }
         
     private:
-        typedef std::map<int, OscSubscriber::Ref> OscSubscribers;
+        using OscSubscribers = std::map<int, OscSubscriber::Ref>;
         void update(ofEventArgs &args) {
             for(OscSubscribers::iterator it = managers.begin(); it != managers.end(); ++it) {
                 it->second->update();
@@ -598,32 +598,32 @@ namespace ofx {
         
 #pragma mark iterator
     public:
-        typedef OscSubscribers::iterator iterator;
-        typedef OscSubscribers::const_iterator const_iterator;
-        typedef OscSubscribers::reverse_iterator reverse_iterator;
-        typedef OscSubscribers::const_reverse_iterator const_reverse_iterator;
+        using iterator = OscSubscribers::iterator;
+        using const_iterator = OscSubscribers::const_iterator;
+        using reverse_iterator = OscSubscribers::reverse_iterator;
+        using const_reverse_iterator = OscSubscribers::const_reverse_iterator;
         
         iterator begin() { return managers.begin(); }
         iterator end() { return managers.end(); }
         
-        const_iterator begin() const { return managers.begin(); }
-        const_iterator end() const { return managers.end(); }
-        const_iterator cbegin() const { return managers.begin(); }
-        const_iterator cend() const { return managers.end(); }
+        const_iterator begin() const { return managers.cbegin(); }
+        const_iterator end() const { return managers.cend(); }
+        const_iterator cbegin() const { return managers.cbegin(); }
+        const_iterator cend() const { return managers.cend(); }
         
         reverse_iterator rbegin() { return managers.rbegin(); }
         reverse_iterator rend() { return managers.rend(); }
         
-        const_reverse_iterator rbegin() const { return managers.rbegin(); }
-        const_reverse_iterator rend() const { return managers.rend(); }
-        const_reverse_iterator crbegin() const { return managers.rbegin(); }
+        const_reverse_iterator rbegin() const { return managers.crbegin(); }
+        const_reverse_iterator rend() const { return managers.crend(); }
+        const_reverse_iterator crbegin() const { return managers.crbegin(); }
         const_reverse_iterator crend() const { return managers.crend(); }
     };
 };
 
-typedef ofx::OscSubscriberManager ofxOscSubscriberManager;
-typedef ofxOscSubscriberManager::OscSubscriber ofxOscSubscriber;
-typedef ofxOscSubscriberManager::Identifier ofxOscSubscriberIdentifier;
+using ofxOscSubscriberManager = ofx::OscSubscriberManager;
+using ofxOscSubscriber = ofxOscSubscriberManager::OscSubscriber;
+using ofxOscSubscriberIdentifier = ofxOscSubscriberManager::Identifier;
 
 /// \brief get a OscSubscriberManager.
 /// \returns ofxOscSubscriberManager

--- a/src/ofxOscSubscriber.h
+++ b/src/ofxOscSubscriber.h
@@ -709,12 +709,10 @@ inline void ofxNotifyToSubscribedOsc(int port, ofxOscMessage &m) {
 }
 
 inline void ofxNotifyToSubscribedOsc(ofxOscMessage &m) {
-    ofxOscSubscriberManager &manager = ofxOscSubscriberManager::getSharedInstance();
-    for(ofxOscSubscriberManager::iterator it  = manager.begin(),
-                                          end = manager.end();
-        it != end;
-        it++)
-    {
+    ofxOscSubscriberManager &manager = ofxGetOscSubscriberManager();
+    ofxOscSubscriberManager::iterator it  = manager.begin(),
+                                      end = manager.end();
+    for(; it != end; it++) {
         it->second->notify(m);
     }
 }

--- a/src/ofxOscSubscriber.h
+++ b/src/ofxOscSubscriber.h
@@ -43,7 +43,7 @@ namespace ofx {
             define_set_arithmetic(double);
 #undef define_set_arithmetic
             
-            inline void set(ofxOscMessage &m, string &v, size_t offset = 0) {
+            inline void set(ofxOscMessage &m, std::string &v, size_t offset = 0) {
                 v = m.getArgAsString(offset);
             }
             
@@ -302,62 +302,62 @@ namespace ofx {
             Callback callback;
         };
 #endif
-        typedef shared_ptr<AbstractParameter> ParameterRef;
-        typedef shared_ptr<ofxOscReceiver> OscReceiverRef;
-        typedef map<string, ParameterRef> Targets;
+        typedef std::shared_ptr<AbstractParameter> ParameterRef;
+        typedef std::shared_ptr<ofxOscReceiver> OscReceiverRef;
+        typedef std::map<std::string, ParameterRef> Targets;
         
     public:
         class OscSubscriber {
         public:
-            inline void subscribe(const string &address, ParameterRef ref) {
+            inline void subscribe(const std::string &address, ParameterRef ref) {
                 Targets::iterator it = targets.find(address);
                 if(it == targets.end()) {
-                    targets.insert(make_pair(address, ref));
+                    targets.insert(std::make_pair(address, ref));
                 } else {
                     it->second = ref;
                 }
             }
             
             template <typename T>
-            inline void subscribe(const string &address, T &value) {
+            inline void subscribe(const std::string &address, T &value) {
                 subscribe(address, ParameterRef(new Parameter<T>(value)));
             }
             
             template <typename T, typename R>
-            inline typename is_not_ofxoscmessage<R>::type subscribe(const string &address, R (*setter)(T)) {
+            inline typename is_not_ofxoscmessage<R>::type subscribe(const std::string &address, R (*setter)(T)) {
                 subscribe(address, ParameterRef(new SetterFunctionParameter<T, R>(setter)));
             }
             
             template <typename T, typename C, typename R>
-            inline typename is_not_ofxoscmessage<R>::type subscribe(const string &address, C &that, R (C::*setter)(T)) {
+            inline typename is_not_ofxoscmessage<R>::type subscribe(const std::string &address, C &that, R (C::*setter)(T)) {
                 subscribe(address, ParameterRef(new SetterMethodParameter<T, C, R>(that, setter)));
             }
             
             template <typename T, typename C, typename R>
-            inline typename is_not_ofxoscmessage<R>::type subscribe(const string &address, const C &that, R (C::*setter)(T) const) {
+            inline typename is_not_ofxoscmessage<R>::type subscribe(const std::string &address, const C &that, R (C::*setter)(T) const) {
                 subscribe(address, ParameterRef(new ConstSetterMethodParameter<T, C, R>(that, setter)));
             }
             
             template <typename T, typename C, typename R>
-            inline typename is_not_ofxoscmessage<R>::type subscribe(const string &address, C *that, R (C::*setter)(T)) {
+            inline typename is_not_ofxoscmessage<R>::type subscribe(const std::string &address, C *that, R (C::*setter)(T)) {
                 subscribe(address, ParameterRef(new SetterMethodParameter<T, C, R>(*that, setter)));
             }
 
-            inline void subscribe(const string &address, void (*callback)(ofxOscMessage &)) {
+            inline void subscribe(const std::string &address, void (*callback)(ofxOscMessage &)) {
                 subscribe(address, ParameterRef(new CallbackParameter(callback)));
             }
             
             template <typename C, typename R>
-            inline void subscribe(const string &address, C &that, R (C::*callback)(ofxOscMessage &)) {
+            inline void subscribe(const std::string &address, C &that, R (C::*callback)(ofxOscMessage &)) {
                 subscribe(address, ParameterRef(new MethodCallbackParameter<C, R>(that, callback)));
             }
             
 #if ENABLE_FUNCTIONAL
-            inline void subscribe(const string &address, std::function<void(ofxOscMessage &)> callback) {
+            inline void subscribe(const std::string &address, std::function<void(ofxOscMessage &)> callback) {
                 subscribe(address, ParameterRef(new LambdaCallbackParameter(callback)));
             }
 #endif
-            inline void unsubscribe(const string &address) {
+            inline void unsubscribe(const std::string &address) {
                 targets.erase(address);
             }
             
@@ -397,7 +397,7 @@ namespace ofx {
                 return targets.empty();
             }
             
-            inline bool isSubscribed(const string &address) const {
+            inline bool isSubscribed(const std::string &address) const {
                 return isSubscribed() && (targets.find(address) != targets.end());
             }
             
@@ -406,8 +406,8 @@ namespace ofx {
             }
             
             void clearLeakedOscMessages() {
-                queue<ofxOscMessage> empty;
-                swap(leakedOscMessages, empty);
+                std::queue<ofxOscMessage> empty;
+                std::swap(leakedOscMessages, empty);
             }
             
             inline bool hasWaitingLeakedOscMessages() const {
@@ -425,13 +425,13 @@ namespace ofx {
             }
             
             void notify(ofxOscMessage & m) {
-                const string &address = m.getAddress();
+                const std::string &address = m.getAddress();
                 if(targets.find(address) != targets.end()) {
                     targets[address]->read(m);
                 }
             }
             
-            typedef shared_ptr<OscSubscriber> Ref;
+            typedef  std::shared_ptr<OscSubscriber> Ref;
         private:
             OscSubscriber(int port)
             : port(port) {
@@ -447,7 +447,7 @@ namespace ofx {
 #else
                     receiver.getNextMessage(m);
 #endif
-                    const string &address = m.getAddress();
+                    const std::string &address = m.getAddress();
                     if(targets.find(address) != targets.end()) {
                         targets[address]->read(m);
                     } else {
@@ -464,7 +464,7 @@ namespace ofx {
             ofxOscReceiver receiver;
             Targets targets;
             ParameterRef leakPicker;
-            queue<ofxOscMessage> leakedOscMessages;
+            std::queue<ofxOscMessage> leakedOscMessages;
             
             friend class OscSubscriberManager;
         };
@@ -477,13 +477,13 @@ namespace ofx {
         static OscSubscriber &getOscSubscriber(int port) {
             OscSubscribers &managers = getSharedInstance().managers;
             if(managers.find(port) == managers.end()) {
-                managers.insert(make_pair(port, OscSubscriber::Ref(new OscSubscriber(port))));
+                managers.insert(std::make_pair(port, OscSubscriber::Ref(new OscSubscriber(port))));
             }
             return *(managers[port].get());
         }
         
     private:
-        typedef map<int, OscSubscriber::Ref> OscSubscribers;
+        typedef std::map<int, OscSubscriber::Ref> OscSubscribers;
         void update(ofEventArgs &args) {
             for(OscSubscribers::iterator it = managers.begin(); it != managers.end(); ++it) {
                 it->second->update();
@@ -520,41 +520,41 @@ inline ofxOscSubscriber &ofxGetOscSubscriber(int port) {
 /// \brief bind a referece of value to the argument(s) of OSC messages with an address pattern _address_ incoming to _port_.
 /// template parameter T is suggested by value
 /// \param port binded port is typed int
-/// \param address osc address is typed const string &
+/// \param address osc address is typed const std::string &
 /// \param value reference of value is typed T &
 /// \returns void
 
 #pragma mark reference
 
 template <typename T>
-inline void ofxSubscribeOsc(int port, const string &address, T &value) {
+inline void ofxSubscribeOsc(int port, const std::string &address, T &value) {
     ofxGetOscSubscriber(port).subscribe(address, value);
 }
 
 #pragma mark setter function/method
 
 template <typename T, typename R>
-inline typename ofxpubsubosc::is_not_ofxoscmessage<T>::type ofxSubscribeOsc(int port, const string &address, R (*callback)(T)) {
+inline typename ofxpubsubosc::is_not_ofxoscmessage<T>::type ofxSubscribeOsc(int port, const std::string &address, R (*callback)(T)) {
     ofxGetOscSubscriber(port).subscribe(address, callback);
 }
 
 template <typename T, typename C, typename R>
-inline typename ofxpubsubosc::is_not_ofxoscmessage<T>::type ofxSubscribeOsc(int port, const string &address, C &that, R (C::*callback)(T)) {
+inline typename ofxpubsubosc::is_not_ofxoscmessage<T>::type ofxSubscribeOsc(int port, const std::string &address, C &that, R (C::*callback)(T)) {
     ofxGetOscSubscriber(port).subscribe(address, that, callback);
 }
 
 template <typename T, typename C, typename R>
-inline typename ofxpubsubosc::is_not_ofxoscmessage<T>::type ofxSubscribeOsc(int port, const string &address, C *that, R (C::*callback)(T)) {
+inline typename ofxpubsubosc::is_not_ofxoscmessage<T>::type ofxSubscribeOsc(int port, const std::string &address, C *that, R (C::*callback)(T)) {
     ofxGetOscSubscriber(port).subscribe(address, *that, callback);
 }
 
 template <typename T, typename C, typename R>
-inline typename ofxpubsubosc::is_not_ofxoscmessage<T>::type ofxSubscribeOsc(int port, const string &address, const C &that, R (C::*callback)(T) const) {
+inline typename ofxpubsubosc::is_not_ofxoscmessage<T>::type ofxSubscribeOsc(int port, const std::string &address, const C &that, R (C::*callback)(T) const) {
     ofxGetOscSubscriber(port).subscribe(address, that, callback);
 }
 
 template <typename T, typename C, typename R>
-inline typename ofxpubsubosc::is_not_ofxoscmessage<T>::type ofxSubscribeOsc(int port, const string &address, const C * const that, R (C::*callback)(T) const) {
+inline typename ofxpubsubosc::is_not_ofxoscmessage<T>::type ofxSubscribeOsc(int port, const std::string &address, const C * const that, R (C::*callback)(T) const) {
     ofxGetOscSubscriber(port).subscribe(address, *that, callback);
 }
 
@@ -562,69 +562,69 @@ inline typename ofxpubsubosc::is_not_ofxoscmessage<T>::type ofxSubscribeOsc(int 
 
 /// \brief bind a callback to the OSC messages with an address pattern _address_ incoming to _port_.
 /// \param port binded port is typed int
-/// \param address osc address is typed const string &
+/// \param address osc address is typed const std::string &
 /// \param callback is kicked when receive a message to address
 /// \returns void
 
-inline void ofxSubscribeOsc(int port, const string &address, void (*callback)(ofxOscMessage &)) {
+inline void ofxSubscribeOsc(int port, const std::string &address, void (*callback)(ofxOscMessage &)) {
     ofxGetOscSubscriber(port).subscribe(address, callback);
 }
 
 /// \brief bind a callback to the OSC messages with an address pattern _address_ incoming to _port_.
 /// template parameter C is suggested by that & callback
 /// \param port binded port is typed int
-/// \param address osc address is typed const string &
+/// \param address osc address is typed const std::string &
 /// \param that this object is typed T&, will bind with next argument of parameter method. is called as (that.*getter)(message) when receive a message.
 /// \param callback has argument ofxOscMessage &
 /// \returns void
 
 template <typename C, typename R>
-inline void ofxSubscribeOsc(int port, const string &address, C &that, R (C::*callback)(ofxOscMessage &)) {
+inline void ofxSubscribeOsc(int port, const std::string &address, C &that, R (C::*callback)(ofxOscMessage &)) {
     ofxGetOscSubscriber(port).subscribe(address, that, callback);
 }
 
 /// \brief bind a callback to the OSC messages with an address pattern _address_ incoming to _port_.
 /// template parameter C is suggested by that & callback
 /// \param port binded port is typed int
-/// \param address osc address is typed const string &
+/// \param address osc address is typed const std::string &
 /// \param that this object is typed T*, will bind with next argument of parameter method. is called as (that->*getter)(message) when receive a message.
 /// \param callback has argument ofxOscMessage &
 /// \returns void
 
 template <typename C, typename R>
-inline void ofxSubscribeOsc(int port, const string &address, C *that, R (C::*callback)(ofxOscMessage &)) {
+inline void ofxSubscribeOsc(int port, const std::string &address, C *that, R (C::*callback)(ofxOscMessage &)) {
     ofxGetOscSubscriber(port).subscribe(address, *that, callback);
 }
 
 /// \brief bind a callback to the OSC messages with an address pattern _address_ incoming to _port_.
 /// template parameter C is suggested by that & callback
 /// \param port binded port is typed int
-/// \param address osc address is typed const string &
+/// \param address osc address is typed const std::string &
 /// \param that this object is typed T&, will bind with next argument of parameter method. is called as (that.*getter)(message) when receive a message.
 /// \param callback has argument ofxOscMessage &
 /// \returns void
 
 template <typename C, typename R>
-inline void ofxSubscribeOsc(int port, const string &address, const C &that, R (C::*callback)(ofxOscMessage &) const) {
+inline void ofxSubscribeOsc(int port, const std::string &address, const C &that, R (C::*callback)(ofxOscMessage &) const) {
     ofxGetOscSubscriber(port).subscribe(address, that, callback);
 }
 
 /// \brief bind a callback to the OSC messages with an address pattern _address_ incoming to _port_.
 /// template parameter C is suggested by that & callback
 /// \param port binded port is typed int
-/// \param address osc address is typed const string &
+/// \param address osc address is typed const std::string &
 /// \param that this object is typed T*, will bind with next argument of parameter method. is called as (that->*getter)(message) when receive a message.
 /// \param callback has argument ofxOscMessage &
 /// \returns void
 
 template <typename C, typename R>
-inline void ofxSubscribeOsc(int port, const string &address, const C *that, R (C::*callback)(ofxOscMessage &) const) {
+inline void ofxSubscribeOsc(int port, const std::string &address, const C *that, R (C::*callback)(ofxOscMessage &) const) {
     ofxGetOscSubscriber(port).subscribe(address, *that, callback);
 }
 
 #if ENABLE_FUNCTIONAL
 template <typename C, typename R>
-inline void ofxSubscribeOsc(int port, const string &address, std::function<void(ofxOscMessage &)> &callback) {
+inline void ofxSubscribeOsc(int port, const std::string &address, std::function<void(ofxOscMessage &)> &callback) {
     ofxGetOscSubscriber(port).subscribe(address, callback);
 }
 #endif
@@ -638,10 +638,10 @@ inline void ofxSubscribeOsc(int port, const string &address, std::function<void(
 
 /// \brief unbind from OSC messages with an address pattern _address_ incoming to _port_.
 /// \param port binded port is typed int
-/// \param address osc address is typed const string &
+/// \param address osc address is typed const std::string &
 /// \returns void
 
-inline void ofxUnsubscribeOsc(int port, const string &address) {
+inline void ofxUnsubscribeOsc(int port, const std::string &address) {
     ofxGetOscSubscriber(port).unsubscribe(address);
 }
 

--- a/src/ofxOscSubscriber.h
+++ b/src/ofxOscSubscriber.h
@@ -838,6 +838,19 @@ inline void ofxSetLeakedOscPicker(int port, std::function<void(ofxOscMessage &)>
 }
 #endif
 
+#if ENABLE_CPP11
+#pragma mark leak picking all port
+
+template <typename T, typename ... Args>
+inline typename std::enable_if<!std::is_integral<T>::value>::type ofxSetLeakedOscPickerAll(T &arg, Args & ... args) {
+    for(auto subscriber : ofxGetOscSubscriberManager()) {
+        subscriber.second->setLeakPicker(arg, args ...);
+    }
+}
+#endif
+
+#pragma mark remove leaked osc picker(s)
+
 /// \brief remove a callback receives messages has leaked patterns incoming to port.
 /// \param port binded port is typed int
 /// \returns void

--- a/src/ofxOscSubscriber.h
+++ b/src/ofxOscSubscriber.h
@@ -320,14 +320,24 @@ namespace ofx {
         typedef std::multimap<std::string, ParameterRef> Targets;
         
         class Identifier {
-            const std::string address;
-            const ParameterRef ref;
+            std::string address;
+            ParameterRef ref;
+            int key;
+            
+            void invalidation() {
+                address = "";
+                ref = nullptr;
+                key = 0;
+            }
         public:
+            Identifier() : address(""), ref(nullptr) {}
             Identifier(const std::string &address, const ParameterRef &ref, int key)
             : address(address)
             , ref(ref)
             , key(key) {}
-            int key;
+            
+            const int getKey() const { return key; };
+            bool isValid() const { return static_cast<bool>(ref); }
             
             friend class OscSubscriber;
         };

--- a/src/ofxOscSubscriber.h
+++ b/src/ofxOscSubscriber.h
@@ -512,14 +512,14 @@ namespace ofx {
         const_iterator begin() const { return managers.cbegin(); }
         const_iterator end() const { return managers.cend(); }
         const_iterator cbegin() const {
-#if __cplusplus <= 199711L
+#if ENABLE_CPP11
             return managers.begin();
 #else
             return managers.cbegin();
 #endif
         }
         const_iterator cend() const {
-#if __cplusplus <= 199711L
+#if ENABLE_CPP11
             return managers.end();
 #else
             return managers.cend();
@@ -532,14 +532,14 @@ namespace ofx {
         const_reverse_iterator rbegin() const { return managers.crbegin(); }
         const_reverse_iterator rend() const { return managers.crend(); }
         const_reverse_iterator crbegin() const {
-#if __cplusplus <= 199711L
+#if ENABLE_CPP11
             return managers.rbegin();
 #else
             return managers.crbegin();
 #endif
         }
         const_reverse_iterator crend() const {
-#if __cplusplus <= 199711L
+#if ENABLE_CPP11
             return managers.rend();
 #else
             return managers.crend();

--- a/src/ofxOscSubscriber.h
+++ b/src/ofxOscSubscriber.h
@@ -700,6 +700,18 @@ inline void ofxUnsubscribeOsc(int port) {
     ofxGetOscSubscriber(port).unsubscribe();
 }
 
+/// \brief unbind from all OSC messages.
+/// \returns void
+
+inline void ofxUnsubscribeOsc() {
+    ofxOscSubscriberManager &manager = ofxGetOscSubscriberManager();
+    ofxOscSubscriberManager::iterator it  = manager.begin(),
+                                      end = manager.end();
+    for(; it != end; it++) {
+        it->second->unsubscribe();
+    }
+}
+
 /// \}
 
 #pragma mark notify messages manually

--- a/src/ofxOscSubscriber.h
+++ b/src/ofxOscSubscriber.h
@@ -498,6 +498,53 @@ namespace ofx {
             ofRemoveListener(ofEvents().update, this, &OscSubscriberManager::update, OF_EVENT_ORDER_BEFORE_APP);
         }
         OscSubscribers managers;
+        
+#pragma mark iterator
+    public:
+        typedef OscSubscribers::iterator iterator;
+        typedef OscSubscribers::const_iterator const_iterator;
+        typedef OscSubscribers::reverse_iterator reverse_iterator;
+        typedef OscSubscribers::const_reverse_iterator const_reverse_iterator;
+        
+        iterator begin() { return managers.begin(); }
+        iterator end() { return managers.end(); }
+        
+        const_iterator begin() const { return managers.cbegin(); }
+        const_iterator end() const { return managers.cend(); }
+        const_iterator cbegin() const {
+#if __cplusplus <= 199711L
+            return managers.begin();
+#else
+            return managers.cbegin();
+#endif
+        }
+        const_iterator cend() const {
+#if __cplusplus <= 199711L
+            return managers.end();
+#else
+            return managers.cend();
+#endif
+        }
+        
+        reverse_iterator rbegin() { return managers.rbegin(); }
+        reverse_iterator rend() { return managers.rend(); }
+        
+        const_reverse_iterator rbegin() const { return managers.crbegin(); }
+        const_reverse_iterator rend() const { return managers.crend(); }
+        const_reverse_iterator crbegin() const {
+#if __cplusplus <= 199711L
+            return managers.rbegin();
+#else
+            return managers.crbegin();
+#endif
+        }
+        const_reverse_iterator crend() const {
+#if __cplusplus <= 199711L
+            return managers.rend();
+#else
+            return managers.crend();
+#endif
+        }
     };
 };
 
@@ -659,6 +706,17 @@ inline void ofxUnsubscribeOsc(int port) {
 
 inline void ofxNotifyToSubscribedOsc(int port, ofxOscMessage &m) {
     ofxGetOscSubscriber(port).notify(m);
+}
+
+inline void ofxNotifyToSubscribedOsc(ofxOscMessage &m) {
+    ofxOscSubscriberManager &manager = ofxOscSubscriberManager::getSharedInstance();
+    for(ofxOscSubscriberManager::iterator it  = manager.begin(),
+                                          end = manager.end();
+        it != end;
+        it++)
+    {
+        it->second->notify(m);
+    }
 }
 
 #pragma mark interface about leaked osc

--- a/src/ofxOscSubscriber.h
+++ b/src/ofxOscSubscriber.h
@@ -520,8 +520,8 @@ namespace ofx {
         iterator begin() { return managers.begin(); }
         iterator end() { return managers.end(); }
         
-        const_iterator begin() const { return managers.cbegin(); }
-        const_iterator end() const { return managers.cend(); }
+        const_iterator begin() const { return managers.begin(); }
+        const_iterator end() const { return managers.end(); }
         const_iterator cbegin() const {
 #if ENABLE_CPP11
             return managers.begin();
@@ -540,8 +540,8 @@ namespace ofx {
         reverse_iterator rbegin() { return managers.rbegin(); }
         reverse_iterator rend() { return managers.rend(); }
         
-        const_reverse_iterator rbegin() const { return managers.crbegin(); }
-        const_reverse_iterator rend() const { return managers.crend(); }
+        const_reverse_iterator rbegin() const { return managers.rbegin(); }
+        const_reverse_iterator rend() const { return managers.rend(); }
         const_reverse_iterator crbegin() const {
 #if ENABLE_CPP11
             return managers.rbegin();

--- a/src/ofxOscSubscriber.h
+++ b/src/ofxOscSubscriber.h
@@ -751,6 +751,12 @@ inline void ofxSubscribeOsc(const std::initializer_list<int> &ports, const std::
 /// \name ofxUnsubscribeOsc
 /// \{
 
+inline void ofxUnsubscribeOsc(const ofxOscSubscriberIdentifier &identifier) {
+    if(!identifier.isValid()) return;
+    ofxGetOscSubscriber(identifier.getKey()).unsubscribe(identifier);
+}
+
+
 /// \brief unbind from OSC messages with an address pattern _address_ incoming to _port_.
 /// \param port binded port is typed int
 /// \param address osc address is typed const std::string &

--- a/src/ofxOscSubscriber.h
+++ b/src/ofxOscSubscriber.h
@@ -551,6 +551,13 @@ namespace ofx {
 typedef ofx::OscSubscriberManager ofxOscSubscriberManager;
 typedef ofxOscSubscriberManager::OscSubscriber ofxOscSubscriber;
 
+/// \brief get a OscSubscriberManager.
+/// \returns ofxOscSubscriberManager
+
+inline ofxOscSubscriberManager &ofxGetOscSubscriberManager() {
+    return ofxOscSubscriberManager::getSharedInstance();
+}
+
 /// \brief get a OscSubscriber.
 /// \param port binded port is typed int
 /// \returns ofxOscSubscriber binded to port


### PR DESCRIPTION
* after this release, we will only test on oF0.9.0~
* add iterators to [ofxOscSubscriberManager](API_Reference.md#Advanced_ofxOscSubscriberManager)
* add all port operation to ofxUnsubscribeOsc, ofxNotifyToSubscribedOsc, ofxRemoveLeakedOscPicker
* add ofxSetLeakedOscPickerAll
* add ofxSubscribeOsc with `std::initializer_list<int> port` and `std::initializer_list<std::string> addresses`
* add iterators to [ofxOscPublisherManager](API_Reference.md#Advanced_ofxOscPublisherManager)
* add all port operation to ofxUnpublishOsc, ofxUnregisterPublishingOsc
* add `std::` prefix
* some bugfix around lambda
* add useful macro `SubscribeOsc(port, name)` is same as `ofxSubscribeOsc(port, "/name", name)` (porposed by [hanasaan](https://github.com/hanasaan). thanks!!)
* cleaning up conditional macro about oF0.8.x
* TODO: update some API Documentations
