### PR TITLE
fix: remove obsolete `#include "ofParameterGroup.h"`

### DIFF
--- a/src/details/Publisher/ofxOscPublisherSetImplementation.h
+++ b/src/details/Publisher/ofxOscPublisherSetImplementation.h
@@ -18,7 +18,6 @@
 
 #include "ofColor.h"
 #include "ofParameter.h"
-#include "ofParameterGroup.h"
 #include "ofUtils.h"
 
 #include <cmath>


### PR DESCRIPTION
[openframeworks/openframeworks#7702 ](https://github.com/openframeworks/openFrameworks/pull/7702) removed the empty header, which broke our build with oF v0.12.1.
Removing the stale #include line.